### PR TITLE
Add outgoing delivered sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ friendly-name pattern; their entity_ids carry the same account suffix:
 | `PostNL (account) En route to PostNL Point` | Active incoming parcels destined for a PostNL Point pickup location |
 | `PostNL (account) Delivered parcels` | Recently delivered incoming parcels (configurable window) |
 | `PostNL (account) Outgoing parcels` | Number of active outgoing parcels |
-| `PostNL (account) Delivered outgoing parcels` | Recently delivered outgoing parcels (same configurable window) |
+| `PostNL (account) Outgoing delivered parcels` | Recently delivered outgoing parcels (same configurable window) |
 | `PostNL (account) Letters` | Letters announced by PostNL's MyMail service over the last ~2 weeks; `unread` count and `letters` list on attributes |
 | `PostNL (account) Letter <title>` (image entity) | Scanned photo of a single announced letter, fetched with your token and served through Home Assistant. Attributes mirror the sensor's letter dict: `id`, `title`, `date`, `unread` |
 

--- a/README.md
+++ b/README.md
@@ -113,8 +113,9 @@ friendly-name pattern; their entity_ids carry the same account suffix:
 | `PostNL (account) Parcel <barcode>` | Canonical status of a single incoming shipment |
 | `PostNL (account) Next delivery` | Earliest expected delivery datetime |
 | `PostNL (account) En route to PostNL Point` | Active incoming parcels destined for a PostNL Point pickup location |
-| `PostNL (account) Delivered parcels` | Recently delivered parcels (configurable window) |
+| `PostNL (account) Delivered parcels` | Recently delivered incoming parcels (configurable window) |
 | `PostNL (account) Outgoing parcels` | Number of active outgoing parcels |
+| `PostNL (account) Delivered outgoing parcels` | Recently delivered outgoing parcels (same configurable window) |
 | `PostNL (account) Letters` | Letters announced by PostNL's MyMail service over the last ~2 weeks; `unread` count and `letters` list on attributes |
 | `PostNL (account) Letter <title>` (image entity) | Scanned photo of a single announced letter, fetched with your token and served through Home Assistant. Attributes mirror the sensor's letter dict: `id`, `title`, `date`, `unread` |
 

--- a/custom_components/postnl/coordinator.py
+++ b/custom_components/postnl/coordinator.py
@@ -32,6 +32,15 @@ from .jouw_api import PostNLJouwAPI
 _LOGGER = logging.getLogger(__name__)
 
 
+# PostNL's status comes from two signals:
+#   - shipment.delivered (bool, GraphQL) — terminal indicator
+#   - colli.statusPhase.message (Track & Trace) — Dutch human-readable string
+#
+# statusPhase.message is not under an API contract: PostNL changes the wording
+# at will. So we substring-match against the meaningful subphrase rather than
+# look up against a fixed enum. Order matters — first match wins, so the more
+# specific patterns must come before the broader ones (e.g. "wordt vandaag
+# bezorgd" before "bezorgd").
 _STATUS_PATTERNS: tuple[tuple[str, ParcelStatus], ...] = (
     ("ligt klaar bij postnl punt", ParcelStatus.AT_PICKUP_POINT),
     ("afgeleverd op postnl punt", ParcelStatus.AT_PICKUP_POINT),
@@ -49,56 +58,92 @@ _STATUS_PATTERNS: tuple[tuple[str, ParcelStatus], ...] = (
     ("bezorgd", ParcelStatus.DELIVERED),
 )
 
+# History events carry a stable PostNL ``observationCode`` (e.g. ``J05``)
+# rather than the brittle human text, so the timeline maps from the code.
+# Unmapped codes resolve to ``None`` (+ a one-shot warning, see feature B).
+# Milestone codes — events that represent a real movement stage. These drive
+# the history ``status`` and progress monotonically (registered → in_transit →
+# out_for_delivery → delivered), with the one legitimate exception of a real
+# delivery delay/failure (G/T codes) dropping back to in_transit.
 _OBSERVATION_CODE_MAP: dict[str, ParcelStatus] = {
-    "A01": ParcelStatus.REGISTERED,
-    "M02": ParcelStatus.REGISTERED,
-    "B01": ParcelStatus.IN_TRANSIT,
-    "J01": ParcelStatus.IN_TRANSIT,
-    "J04": ParcelStatus.IN_TRANSIT,
-    "J21": ParcelStatus.IN_TRANSIT,
-    "J31": ParcelStatus.IN_TRANSIT,
-    "J32": ParcelStatus.IN_TRANSIT,
-    "J40": ParcelStatus.IN_TRANSIT,
-    "J44": ParcelStatus.IN_TRANSIT,
-    "J55": ParcelStatus.IN_TRANSIT,
-    "G01": ParcelStatus.IN_TRANSIT,
-    "G05": ParcelStatus.IN_TRANSIT,
-    "T04": ParcelStatus.IN_TRANSIT,
-    "J05": ParcelStatus.OUT_FOR_DELIVERY,
-    "I08": ParcelStatus.AT_PICKUP_POINT,
-    "J02": ParcelStatus.AT_PICKUP_POINT,
-    "J12": ParcelStatus.AT_PICKUP_POINT,
-    "A80": ParcelStatus.DELIVERED,
-    "I01": ParcelStatus.DELIVERED,
-    "I02": ParcelStatus.DELIVERED,
-    "I05": ParcelStatus.DELIVERED,
+    # --- Pre-receipt baseline (registered) ---
+    "A01": ParcelStatus.REGISTERED,       # nog niet ontvangen/verwerkt
+    "M02": ParcelStatus.REGISTERED,       # nog niet ontvangen/verwerkt (variant of A01)
+    # --- In the network (in_transit) ---
+    "B01": ParcelStatus.IN_TRANSIT,       # ontvangen door PostNL
+    "J01": ParcelStatus.IN_TRANSIT,       # gesorteerd
+    "J04": ParcelStatus.IN_TRANSIT,       # voorgemeld en gescand op rit
+    "J21": ParcelStatus.IN_TRANSIT,       # overgedragen aan afhaallocatie (handover, not yet ready)
+    "J31": ParcelStatus.IN_TRANSIT,       # ingenomen aan de sorteergoot
+    "J32": ParcelStatus.IN_TRANSIT,       # overgedragen tijdens route
+    "J40": ParcelStatus.IN_TRANSIT,       # voorgemeld en gesorteerd op rit
+    "J44": ParcelStatus.IN_TRANSIT,       # overgenomen tijdens route
+    "J55": ParcelStatus.IN_TRANSIT,       # verwacht bij PostNL-punt
+    # --- Real delivery delay / failed attempt: a genuine step back to transit ---
+    "G01": ParcelStatus.IN_TRANSIT,       # bezorgmoment bijgewerkt — lukt vandaag niet
+    "G05": ParcelStatus.IN_TRANSIT,       # bezorgmoment bijgewerkt (delay)
+    "T04": ParcelStatus.IN_TRANSIT,       # bezorgmoment bijgewerkt (delay)
+    # --- Out for delivery ---
+    "J05": ParcelStatus.OUT_FOR_DELIVERY, # bezorger is onderweg
+    # --- At a pickup point ---
+    "I08": ParcelStatus.AT_PICKUP_POINT,  # zending beschikbaar op PostNL-punt
+    "J02": ParcelStatus.AT_PICKUP_POINT,  # ligt klaar bij PostNL-punt
+    "J12": ParcelStatus.AT_PICKUP_POINT,  # ligt klaar bij PostNL-punt
+    # --- Delivered / collected (terminal) ---
+    "A80": ParcelStatus.DELIVERED,        # handtekening voor pakket ontvangen (proof of delivery)
+    "I01": ParcelStatus.DELIVERED,        # pakket is bezorgd
+    "I02": ParcelStatus.DELIVERED,        # afgehaald bij PostNL-punt
+    "I05": ParcelStatus.DELIVERED,        # bezorgd in de brievenbus
 }
 
+# Known notification / admin / data events that are NOT a movement milestone.
+# PostNL interleaves these throughout the timeline (often out of order), so
+# mapping them to a movement status makes the history bounce back and forth
+# (e.g. an "ETA gewijzigd" right after "Bezorger is onderweg" would otherwise
+# drag the status from out_for_delivery back to in_transit). They resolve to
+# ``status: null`` — known, so no "unrecognised" warning — while the exact
+# label is preserved on ``raw_status``.
 _OBSERVATION_META_CODES: frozenset[str] = frozenset({
-    "A04",
-    "A18",
-    "A19",
-    "A25",
-    "A65",
-    "A94",
-    "A95",
-    "A96",
-    "A98",
-    "K33",
+    "A04",  # PIOS melding (notification)
+    "A18",  # ETA initieel bepaald
+    "A19",  # ETA gewijzigd
+    "A25",  # reminderservice notificaties
+    "A65",  # zending herpland (planning change)
+    "A94",  # zelf bezorging gewijzigd
+    "A95",  # bezorging wijzigen niet mogelijk
+    "A96",  # bezorging wijzigen mogelijk
+    "A98",  # voorgemelde zending verrijkt door PostNL regie (data enrichment)
+    "K33",  # "leeg" placeholder
 })
 
+# New-issue link surfaced in the unknown-status warnings so users can paste a
+# ready-made line into a bug report.
 _NEW_ISSUE_URL = "https://github.com/peternijssen/ha-postnl/issues/new"
 
+# One-shot dedupe sets so each distinct unmapped value warns once per HA
+# session rather than on every poll.
 _LOGGED_UNKNOWN_STATUSES: set[str] = set()
 _LOGGED_UNKNOWN_OBSERVATION_CODES: set[str] = set()
 
 
 def _refresh_interval(entry: ConfigEntry) -> timedelta:
-    minutes = int(entry.options.get(CONF_REFRESH_INTERVAL, DEFAULT_REFRESH_INTERVAL))
+    """Return the configured refresh interval from the config entry options."""
+    minutes = int(
+        entry.options.get(CONF_REFRESH_INTERVAL, DEFAULT_REFRESH_INTERVAL)
+    )
     return timedelta(minutes=minutes)
 
 
 def map_parcel_status(parcel: dict) -> ParcelStatus:
+    """Map a PostNL parcel dict to a canonical :class:`ParcelStatus`.
+
+    ``parcel`` is the intermediate dict built by :meth:`transform_shipment`
+    with at least ``delivered`` (bool) and ``status_message`` (str) populated.
+    The ``delivered`` flag from GraphQL is authoritative and short-circuits to
+    :attr:`ParcelStatus.DELIVERED`. Anything that does not match any pattern
+    is reported as :attr:`ParcelStatus.UNKNOWN` and surfaced once at info
+    level so users can open an issue to extend the map.
+    """
     if parcel.get("delivered"):
         return ParcelStatus.DELIVERED
 
@@ -122,20 +167,34 @@ def map_parcel_status(parcel: dict) -> ParcelStatus:
     return ParcelStatus.UNKNOWN
 
 
-def map_observation_status(code: str | None, description: str | None) -> ParcelStatus | None:
-    if code is None:
-        return None
-    if code in _OBSERVATION_META_CODES:
+def map_observation_status(
+    code: str | None, description: str | None = None
+) -> ParcelStatus | None:
+    """Map a Track & Trace ``observationCode`` to a canonical milestone status.
+
+    Returns a :class:`ParcelStatus` only for genuine movement milestones.
+    Known notification/admin codes (:data:`_OBSERVATION_META_CODES`) and
+    unmapped codes both return ``None``; meta codes do so silently, while an
+    unmapped code surfaces a one-shot warning with copy-paste issue text so
+    users can help extend the map. :func:`build_history` decides what a
+    ``None`` becomes (carry the previous stage forward for meta, leave null
+    for unknown).
+    """
+    if not code:
         return None
     status = _OBSERVATION_CODE_MAP.get(code)
     if status is not None:
         return status
+
+    if code in _OBSERVATION_META_CODES:
+        return None  # known notification/admin event — no own movement status
+
     if code not in _LOGGED_UNKNOWN_OBSERVATION_CODES:
         _LOGGED_UNKNOWN_OBSERVATION_CODES.add(code)
         _LOGGER.warning(
-            "Unrecognised PostNL observation code — help us map it. Open an "
-            "issue and paste this line: %s\n  [history] observationCode=%r "
-            "description=%r → status omitted from timeline",
+            "Unrecognised PostNL status — help us map it. Open an issue and "
+            "paste this line: %s\n  [history] observationCode=%s text=%r "
+            "→ reported as 'unknown'",
             _NEW_ISSUE_URL,
             code,
             description,
@@ -143,9 +202,85 @@ def map_observation_status(code: str | None, description: str | None) -> ParcelS
     return None
 
 
+def _extract_observations(colli: dict) -> list[dict]:
+    """Return the status-event list from a colli object, oldest-first preferred.
+
+    ``analyticsInfo.allObservations`` carries the **complete** timeline
+    (oldest-first); the top-level ``observations`` list is truncated to the
+    most recent few. Prefer the former, fall back to the latter.
+    """
+    analytics = colli.get("analyticsInfo") or {}
+    return analytics.get("allObservations") or colli.get("observations") or []
+
+
+def build_history(
+    observations: list[dict] | None, *, max_events: int = HISTORY_MAX_EVENTS
+) -> list[dict]:
+    """Build the canonical ``history`` list from raw Track & Trace observations.
+
+    Each entry is ``{timestamp, status, raw_status}`` — identical across all
+    suite carriers. Sorted oldest → newest by timestamp (entries with an
+    unparseable timestamp keep their original order, after the parseable ones)
+    and capped to the most recent ``max_events``.
+
+    PostNL interleaves notification/admin events (ETA recalcs, "bezorging
+    wijzigen mogelijk", data enrichment, …) throughout the timeline, often out
+    of order. Those carry **no movement status of their own**; instead they
+    inherit the stage of the most recent milestone (carry-forward), so the
+    timeline never bounces backwards on a cosmetic event — e.g. an "ETA
+    gewijzigd" logged the moment the courier sets off reads ``out_for_delivery``,
+    while the same code earlier (just after sorting) reads ``in_transit``.
+    Genuine milestones drive the status and only a real delivery delay (G/T)
+    steps back to ``in_transit``. Unmapped codes stay ``null`` (+ warning).
+    """
+    parseable: list[tuple[datetime, tuple]] = []
+    unparseable: list[tuple] = []
+    for obs in observations or []:
+        timestamp = obs.get("observationDate")
+        if not timestamp:
+            continue
+        record = (timestamp, obs.get("observationCode"), obs.get("description"))
+        dt = _parse_iso(timestamp)
+        if dt is None:
+            unparseable.append(record)
+        else:
+            parseable.append((dt, record))
+    parseable.sort(key=lambda item: item[0])
+    ordered = [record for _, record in parseable] + unparseable
+
+    history: list[dict] = []
+    # A parcel that appears in track-trace has, at minimum, been pre-announced,
+    # so the implicit baseline stage is REGISTERED. This is what a meta event
+    # (e.g. "Voorgemelde zending verrijkt") inherits when it lands before the
+    # first real milestone, instead of showing a bare null.
+    last_status: ParcelStatus | None = ParcelStatus.REGISTERED
+    for timestamp, code, description in ordered:
+        status = map_observation_status(code, description)
+        if status is not None:
+            last_status = status
+        elif code in _OBSERVATION_META_CODES:
+            # Known notification/admin event — show the stage the parcel was
+            # already in rather than inventing a (backwards) movement.
+            status = last_status
+        # else: unmapped → leave None (map_observation_status already warned)
+        history.append(
+            {"timestamp": timestamp, "status": status, "raw_status": description}
+        )
+    return history[-max_events:]
+
+
 def _convert_native_dimensions(
     native: dict | None,
 ) -> tuple[float | None, dict | None]:
+    """Convert PostNL's native dimensions (g + mm) to the suite-wide canonical
+    shape (kg + cm with a pre-formatted ``text`` string).
+
+    PostNL ships ``{height, width, depth, weight}`` in grams + millimetres,
+    and calls the long edge ``depth`` rather than ``length``. The canonical
+    contract every other carrier in the suite honours is kg + cm + ``length``,
+    with a pre-formatted ``"L x W x H cm"`` string under ``text`` so dashboard
+    cards can render it directly.
+    """
     if not native:
         return None, None
     weight_g = native.get("weight")
@@ -168,6 +303,18 @@ def _convert_native_dimensions(
 
 
 def normalize_parcel(parcel: dict, *, history: list[dict] | None = None) -> dict:
+    """Wrap a transformed PostNL parcel in the canonical carrier-agnostic shape.
+
+    Top-level keys mirror DHL / DPD / parcel-aggregator. The original
+    transformed PostNL payload (GraphQL + Track & Trace fields like
+    ``status_message``, ``delivery_address_type``, ``planned_date``,
+    ``expected_datetime`` and the native ``dimensions`` dict in g + mm)
+    is preserved under ``raw`` for power users.
+
+    ``history`` is the optional per-parcel status timeline (opt-in option,
+    default off → ``None``). It stays top-level so it survives the
+    aggregator's ``strip_raw()`` and flows through unchanged.
+    """
     delivered = bool(parcel.get("delivered"))
     weight_kg, canonical_dimensions = _convert_native_dimensions(
         parcel.get("dimensions")
@@ -194,6 +341,11 @@ def normalize_parcel(parcel: dict, *, history: list[dict] | None = None) -> dict
 
 
 def _parse_iso(value: str | None) -> datetime | None:
+    """Parse an ISO 8601 string to an aware datetime, or ``None`` on failure.
+
+    PostNL mixes offset-aware and naive timestamps in the same payload; naive
+    values are treated as UTC so a mixed list still sorts without crashing.
+    """
     if not value:
         return None
     try:
@@ -206,12 +358,19 @@ def _parse_iso(value: str | None) -> datetime | None:
 
 
 def _delivery_dt(parcel: dict) -> datetime | None:
+    """Parse the delivery datetime from a normalised parcel dict."""
     return _parse_iso(parcel.get("delivered_at"))
 
 
 def sort_parcels_by_ts(
     parcels: list[dict], key_field: str, *, descending: bool = False
 ) -> list[dict]:
+    """Return normalised parcels sorted by the ISO timestamp at ``key_field``.
+
+    Parcels whose value is missing or unparseable always sort to the end,
+    regardless of ``descending`` — so freshly registered parcels without
+    an ETA stay visible at the bottom instead of jumping to the top.
+    """
     with_ts: list[tuple[datetime, dict]] = []
     without_ts: list[dict] = []
     for parcel in parcels:
@@ -224,48 +383,13 @@ def sort_parcels_by_ts(
         except ValueError:
             without_ts.append(parcel)
             continue
+        # PostNL mixes offset-aware and naive timestamps in the same payload;
+        # treat naive values as UTC so the sort doesn't crash on a mixed list.
         if dt.tzinfo is None:
             dt = dt.replace(tzinfo=timezone.utc)
         with_ts.append((dt, parcel))
     with_ts.sort(key=lambda item: item[0], reverse=descending)
     return [p for _, p in with_ts] + without_ts
-
-
-def _extract_observations(colli: dict) -> list[dict]:
-    analytics = colli.get("analyticsInfo") or {}
-    return analytics.get("allObservations") or colli.get("observations") or []
-
-
-def build_history(
-    observations: list[dict] | None, *, max_events: int = HISTORY_MAX_EVENTS
-) -> list[dict]:
-    parseable: list[tuple[datetime, tuple]] = []
-    unparseable: list[tuple] = []
-    for obs in observations or []:
-        timestamp = obs.get("observationDate")
-        if not timestamp:
-            continue
-        record = (timestamp, obs.get("observationCode"), obs.get("description"))
-        dt = _parse_iso(timestamp)
-        if dt is None:
-            unparseable.append(record)
-        else:
-            parseable.append((dt, record))
-    parseable.sort(key=lambda item: item[0])
-    ordered = [record for _, record in parseable] + unparseable
-
-    history: list[dict] = []
-    last_status: ParcelStatus | None = ParcelStatus.REGISTERED
-    for timestamp, code, description in ordered:
-        status = map_observation_status(code, description)
-        if status is not None:
-            last_status = status
-        elif code in _OBSERVATION_META_CODES:
-            status = last_status
-        history.append(
-            {"timestamp": timestamp, "status": status, "raw_status": description}
-        )
-    return history[-max_events:]
 
 
 _DUTCH_MONTHS = {
@@ -276,6 +400,12 @@ _DUTCH_MONTHS = {
 
 
 def parse_letter_date(title: str, *, today: datetime | None = None) -> str | None:
+    """Convert a Dutch day-month title like '16 juni' into an ISO date string.
+
+    The MyMail endpoint returns dates without a year. We infer the year from
+    ``today``: if the parsed month/day is more than 31 days ahead of today, it
+    must belong to the previous year (PostNL only retains 2 weeks of mail).
+    """
     if not title:
         return None
     parts = title.strip().lower().split()
@@ -302,6 +432,7 @@ def parse_letter_date(title: str, *, today: datetime | None = None) -> str | Non
 
 
 def extract_letters(payload: dict, *, today: datetime | None = None) -> list[dict]:
+    """Extract letter entries from the server-driven-UI MyMail response."""
     sections = ((payload or {}).get("screen") or {}).get("sections") or []
     letters: list[dict] = []
     for section in sections:
@@ -334,19 +465,61 @@ class PostNLCoordinator(DataUpdateCoordinator):
         self.delivered_receiver: list[dict] = []
         self.delivered_sender: list[dict] = []
         self.letters: list[dict] = []
+        # API clients are reused across polls (each PostNLJouwAPI owns a
+        # requests.Session with a connection pool); they are only rebuilt
+        # when the access token actually changes.
         self.graphq_api: PostNLGraphql | None = None
         self.jouw_api: PostNLJouwAPI | None = None
         self._api_token: str | None = None
+        # barcode -> last seen ParcelStatus. ``None`` on the first refresh so
+        # we can suppress events for parcels that already existed when the
+        # integration started (we do not know their previous state).
         self._known_state: dict[str, ParcelStatus] | None = None
+        # barcode -> last seen (planned_from, planned_to) tuple. Mirrors
+        # ``_known_state`` for delivery-time-change detection.
         self._known_delivery_times: (
             dict[str, tuple[str | None, str | None]] | None
         ) = None
+        # Letter ids seen on the previous successful letters fetch. ``None``
+        # on the first refresh for the same reason — we do not want to fire
+        # ``postnl_letter_announced`` for every letter that already existed.
         self._known_letter_ids: set[str] | None = None
+        # barcode -> last successfully transformed (normalized) parcel, so a
+        # transient Track & Trace failure for one parcel degrades to its
+        # previous data instead of failing the whole refresh.
         self._parcel_cache: dict[str, dict] = {}
+        # barcode -> history timeline for *delivered* parcels. A delivered
+        # parcel's history never changes, so the extra T&T call is made at
+        # most once per barcode instead of on every poll.
         self._delivered_history_cache: dict[str, list[dict] | None] = {}
+        # Cached device id for this account, attached to every fired event so
+        # device-trigger automations can filter to a specific PostNL account.
+        # ``None`` until the device exists (i.e. the sensors are set up).
         self._cached_device_id: str | None = None
+        # Timestamp of the last successful poll, surfaced by a diagnostic
+        # sensor so users can alert on a silently-stale integration (the
+        # count sensors only change when a value changes, not every poll).
         self.last_success_time: datetime | None = None
         _LOGGER.debug("PostNLCoordinator initialized with update interval: %s", self.update_interval)
+
+    def _device_id(self) -> str | None:
+        """Resolve (and cache) this account's device id for event payloads.
+
+        Looked up from the device registry by config entry. Stays ``None``
+        until the device has been registered (the sensors create it on first
+        setup), which is harmless because events are suppressed on the very
+        first refresh anyway.
+        """
+        if self._cached_device_id is not None:
+            return self._cached_device_id
+        registry = dr.async_get(self.hass)
+        device = next(
+            iter(dr.async_entries_for_config_entry(registry, self.config_entry.entry_id)),
+            None,
+        )
+        if device is not None:
+            self._cached_device_id = device.id
+        return self._cached_device_id
 
     async def _async_update_data(self) -> dict[str, list[dict]]:
         _LOGGER.debug("Starting data update for PostNL.")
@@ -379,6 +552,8 @@ class PostNLCoordinator(DataUpdateCoordinator):
             data['receiver'] = sort_parcels_by_ts(data['receiver'], 'planned_from')
             data['sender'] = sort_parcels_by_ts(data['sender'], 'planned_from')
 
+            # Keep the fallback/history caches bounded to barcodes PostNL
+            # still reports; anything older can never be needed again.
             current_barcodes = {
                 p.get('barcode') for p in data['receiver'] if p.get('barcode')
             }
@@ -413,7 +588,7 @@ class PostNLCoordinator(DataUpdateCoordinator):
 
             delivered_sender = [p for p in data['sender'] if p.get('delivered')]
             self.delivered_sender = sort_parcels_by_ts(
-                self._apply_delivered_filter(delivered_sender),
+                delivered_sender,
                 'delivered_at',
                 descending=True,
             )
@@ -443,6 +618,17 @@ class PostNLCoordinator(DataUpdateCoordinator):
             raise UpdateFailed("Unable to update PostNL data") from exception
 
     def _fire_change_events(self, parcels: list[dict]) -> None:
+        """Fire events for newly-registered parcels and parcel transitions.
+
+        Silent on the very first refresh — we cannot reliably know which
+        parcels are "new" to the user vs. "already there before HA started".
+        From the second refresh onward, every parcel that was not present
+        before yields one ``postnl_parcel_registered`` event, every parcel
+        whose normalised status changed yields one
+        ``postnl_parcel_status_changed`` event, and every parcel whose
+        ``planned_from`` or ``planned_to`` changed to a non-null value
+        yields one ``postnl_parcel_delivery_time_changed`` event.
+        """
         if self._known_state is None:
             return
 
@@ -475,6 +661,11 @@ class PostNLCoordinator(DataUpdateCoordinator):
             old_from, old_to = known_times.get(barcode, (None, None))
             new_from = parcel.get("planned_from")
             new_to = parcel.get("planned_to")
+            # Fire only when at least one of the two ends up with a real
+            # (non-null) value AND that value differs from the last-known
+            # one. value -> null transitions are intentionally silent —
+            # they mean the carrier dropped the ETA, which is not what
+            # users want to be paged about.
             from_changed = new_from is not None and new_from != old_from
             to_changed = new_to is not None and new_to != old_to
             if from_changed or to_changed:
@@ -491,6 +682,14 @@ class PostNLCoordinator(DataUpdateCoordinator):
                 )
 
     def _fire_letter_events(self, letters: list[dict]) -> None:
+        """Fire ``postnl_letter_announced`` for newly-seen letter ids.
+
+        Silent on the very first refresh — we cannot tell which letters
+        are "new" vs "already announced before HA started". From the
+        second refresh onward, every letter whose id was not present in
+        the previous successful fetch yields one event with the full
+        letter payload plus ``carrier: "PostNL"``.
+        """
         if self._known_letter_ids is None:
             return
         device_id = self._device_id()
@@ -504,6 +703,7 @@ class PostNLCoordinator(DataUpdateCoordinator):
             )
 
     def _apply_delivered_filter(self, parcels: list[dict]) -> list[dict]:
+        """Trim the delivered receiver list according to the configured options."""
         options = self.config_entry.options
         filter_type = options.get(CONF_DELIVERED_FILTER_TYPE, DEFAULT_DELIVERED_FILTER_TYPE)
         filter_amount = int(options.get(CONF_DELIVERED_FILTER_AMOUNT, DEFAULT_DELIVERED_FILTER_AMOUNT))
@@ -516,11 +716,25 @@ class PostNLCoordinator(DataUpdateCoordinator):
 
     @property
     def _include_history(self) -> bool:
+        """Whether the opt-in per-parcel history option is enabled."""
         return bool(
-            self.config_entry.options.get(CONF_INCLUDE_HISTORY, DEFAULT_INCLUDE_HISTORY)
+            self.config_entry.options.get(
+                CONF_INCLUDE_HISTORY, DEFAULT_INCLUDE_HISTORY
+            )
         )
 
     def _delivered_history(self, shipment) -> list[dict] | None:
+        """Fetch a history timeline for a delivered shipment (opt-in only).
+
+        The active path gets observations from the Track & Trace call it
+        already makes, but delivered parcels normally skip that call. When the
+        history option is on we make the extra call here so delivered parcels
+        get parity with DHL / DPD. A delivered parcel's history never changes,
+        so a successful fetch is cached per barcode — one call per parcel
+        ever, not one per poll. A failure is non-fatal — history is a
+        nice-to-have, so we log and fall back to ``None`` (uncached, so the
+        next poll retries) rather than failing the whole refresh.
+        """
         if not self._include_history:
             return None
         barcode = shipment.get('barcode')
@@ -540,18 +754,6 @@ class PostNLCoordinator(DataUpdateCoordinator):
             self._delivered_history_cache[barcode] = history
         return history
 
-    def _device_id(self) -> str | None:
-        if self._cached_device_id is not None:
-            return self._cached_device_id
-        registry = dr.async_get(self.hass)
-        device = next(
-            iter(dr.async_entries_for_config_entry(registry, self.config_entry.entry_id)),
-            None,
-        )
-        if device is not None:
-            self._cached_device_id = device.id
-        return self._cached_device_id
-
     async def transform_shipment(self, shipment) -> dict:
         _LOGGER.debug('Updating %s', shipment.get('key'))
 
@@ -561,6 +763,12 @@ class PostNLCoordinator(DataUpdateCoordinator):
             if shipment.get('delivered'):
                 _LOGGER.debug('%s already delivered, no need to call jouw.postnl.', shipment.get('key'))
 
+                # Delivered short-circuits the Track & Trace call, so there's no
+                # ``colli.recipient.names.personName`` to read — the GraphQL
+                # ``receiverTitle`` is the equivalent. No weight/dimensions
+                # available on this path; the suite contract accepts those as
+                # ``None``. History is the one exception: when the opt-in
+                # option is on we make an extra T&T call for the timeline.
                 history = await self.hass.async_add_executor_job(
                     self._delivered_history, shipment
                 )
@@ -594,6 +802,9 @@ class PostNLCoordinator(DataUpdateCoordinator):
                     self.jouw_api.track_and_trace, shipment['key']
                 )
             except requests.exceptions.RequestException as exception:
+                # One broken T&T call must not fail the whole refresh. Degrade
+                # per parcel: reuse the last successful transform when we have
+                # one, otherwise fall through with the GraphQL-only fields.
                 barcode = shipment.get('barcode')
                 cached = self._parcel_cache.get(barcode) if barcode else None
                 if cached is not None:
@@ -642,6 +853,8 @@ class PostNLCoordinator(DataUpdateCoordinator):
                     colli.get('recipient', {}).get('names', {}).get('personName')
                 )
                 native_dimensions = (colli.get('details') or {}).get('dimensions')
+                # The active T&T call already carries the timeline; only build
+                # it when the opt-in option is on.
                 history = (
                     build_history(_extract_observations(colli))
                     if self._include_history
@@ -660,6 +873,10 @@ class PostNLCoordinator(DataUpdateCoordinator):
                 "url": shipment.get('detailsUrl'),
                 "shipment_type": shipment.get('shipmentType'),
                 "receiver_title": receiver_title,
+                # ``recipient.personName`` from Track & Trace is the
+                # authoritative recipient name on the active path;
+                # ``receiverTitle`` is the GraphQL fallback for when T&T
+                # doesn't have it yet (first poll after registration).
                 "receiver": recipient_name or receiver_title,
                 "source_display_name": (
                         (shipment.get('sourceDisplayName') or '').strip()
@@ -674,13 +891,22 @@ class PostNLCoordinator(DataUpdateCoordinator):
                 "planned_from": planned_from,
                 "planned_to": planned_to,
                 "expected_datetime": expected_datetime,
+                # Native PostNL dimensions (g + mm). Lives on the
+                # intermediate dict so it surfaces under ``raw`` for power
+                # users; ``normalize_parcel`` reads it and produces the
+                # canonical kg + cm + ``text`` shape at the top level.
                 "dimensions": native_dimensions,
             }, history=history)
             barcode = shipment.get('barcode')
             if barcode and colli:
+                # Only a transform backed by real T&T data is worth reusing
+                # as a fallback on a later transient failure.
                 self._parcel_cache[barcode] = parcel
             return parcel
         except requests.exceptions.RequestException as exception:
+            # Safety net for requests errors outside the targeted T&T catch.
+            # Degrade to the last successful transform when we have one; only
+            # fail the refresh when there is nothing to show for this parcel.
             _LOGGER.error("Error fetching Track and Trace details for shipment %s: %s", shipment.get('key'), exception, exc_info=True)
             barcode = shipment.get('barcode')
             cached = self._parcel_cache.get(barcode) if barcode else None

--- a/custom_components/postnl/coordinator.py
+++ b/custom_components/postnl/coordinator.py
@@ -588,7 +588,7 @@ class PostNLCoordinator(DataUpdateCoordinator):
 
             delivered_sender = [p for p in data['sender'] if p.get('delivered')]
             self.delivered_sender = sort_parcels_by_ts(
-                delivered_sender,
+                self._apply_delivered_filter(delivered_sender),
                 'delivered_at',
                 descending=True,
             )

--- a/custom_components/postnl/coordinator.py
+++ b/custom_components/postnl/coordinator.py
@@ -32,15 +32,6 @@ from .jouw_api import PostNLJouwAPI
 _LOGGER = logging.getLogger(__name__)
 
 
-# PostNL's status comes from two signals:
-#   - shipment.delivered (bool, GraphQL) — terminal indicator
-#   - colli.statusPhase.message (Track & Trace) — Dutch human-readable string
-#
-# statusPhase.message is not under an API contract: PostNL changes the wording
-# at will. So we substring-match against the meaningful subphrase rather than
-# look up against a fixed enum. Order matters — first match wins, so the more
-# specific patterns must come before the broader ones (e.g. "wordt vandaag
-# bezorgd" before "bezorgd").
 _STATUS_PATTERNS: tuple[tuple[str, ParcelStatus], ...] = (
     ("ligt klaar bij postnl punt", ParcelStatus.AT_PICKUP_POINT),
     ("afgeleverd op postnl punt", ParcelStatus.AT_PICKUP_POINT),
@@ -58,92 +49,56 @@ _STATUS_PATTERNS: tuple[tuple[str, ParcelStatus], ...] = (
     ("bezorgd", ParcelStatus.DELIVERED),
 )
 
-# History events carry a stable PostNL ``observationCode`` (e.g. ``J05``)
-# rather than the brittle human text, so the timeline maps from the code.
-# Unmapped codes resolve to ``None`` (+ a one-shot warning, see feature B).
-# Milestone codes — events that represent a real movement stage. These drive
-# the history ``status`` and progress monotonically (registered → in_transit →
-# out_for_delivery → delivered), with the one legitimate exception of a real
-# delivery delay/failure (G/T codes) dropping back to in_transit.
 _OBSERVATION_CODE_MAP: dict[str, ParcelStatus] = {
-    # --- Pre-receipt baseline (registered) ---
-    "A01": ParcelStatus.REGISTERED,       # nog niet ontvangen/verwerkt
-    "M02": ParcelStatus.REGISTERED,       # nog niet ontvangen/verwerkt (variant of A01)
-    # --- In the network (in_transit) ---
-    "B01": ParcelStatus.IN_TRANSIT,       # ontvangen door PostNL
-    "J01": ParcelStatus.IN_TRANSIT,       # gesorteerd
-    "J04": ParcelStatus.IN_TRANSIT,       # voorgemeld en gescand op rit
-    "J21": ParcelStatus.IN_TRANSIT,       # overgedragen aan afhaallocatie (handover, not yet ready)
-    "J31": ParcelStatus.IN_TRANSIT,       # ingenomen aan de sorteergoot
-    "J32": ParcelStatus.IN_TRANSIT,       # overgedragen tijdens route
-    "J40": ParcelStatus.IN_TRANSIT,       # voorgemeld en gesorteerd op rit
-    "J44": ParcelStatus.IN_TRANSIT,       # overgenomen tijdens route
-    "J55": ParcelStatus.IN_TRANSIT,       # verwacht bij PostNL-punt
-    # --- Real delivery delay / failed attempt: a genuine step back to transit ---
-    "G01": ParcelStatus.IN_TRANSIT,       # bezorgmoment bijgewerkt — lukt vandaag niet
-    "G05": ParcelStatus.IN_TRANSIT,       # bezorgmoment bijgewerkt (delay)
-    "T04": ParcelStatus.IN_TRANSIT,       # bezorgmoment bijgewerkt (delay)
-    # --- Out for delivery ---
-    "J05": ParcelStatus.OUT_FOR_DELIVERY, # bezorger is onderweg
-    # --- At a pickup point ---
-    "I08": ParcelStatus.AT_PICKUP_POINT,  # zending beschikbaar op PostNL-punt
-    "J02": ParcelStatus.AT_PICKUP_POINT,  # ligt klaar bij PostNL-punt
-    "J12": ParcelStatus.AT_PICKUP_POINT,  # ligt klaar bij PostNL-punt
-    # --- Delivered / collected (terminal) ---
-    "A80": ParcelStatus.DELIVERED,        # handtekening voor pakket ontvangen (proof of delivery)
-    "I01": ParcelStatus.DELIVERED,        # pakket is bezorgd
-    "I02": ParcelStatus.DELIVERED,        # afgehaald bij PostNL-punt
-    "I05": ParcelStatus.DELIVERED,        # bezorgd in de brievenbus
+    "A01": ParcelStatus.REGISTERED,
+    "M02": ParcelStatus.REGISTERED,
+    "B01": ParcelStatus.IN_TRANSIT,
+    "J01": ParcelStatus.IN_TRANSIT,
+    "J04": ParcelStatus.IN_TRANSIT,
+    "J21": ParcelStatus.IN_TRANSIT,
+    "J31": ParcelStatus.IN_TRANSIT,
+    "J32": ParcelStatus.IN_TRANSIT,
+    "J40": ParcelStatus.IN_TRANSIT,
+    "J44": ParcelStatus.IN_TRANSIT,
+    "J55": ParcelStatus.IN_TRANSIT,
+    "G01": ParcelStatus.IN_TRANSIT,
+    "G05": ParcelStatus.IN_TRANSIT,
+    "T04": ParcelStatus.IN_TRANSIT,
+    "J05": ParcelStatus.OUT_FOR_DELIVERY,
+    "I08": ParcelStatus.AT_PICKUP_POINT,
+    "J02": ParcelStatus.AT_PICKUP_POINT,
+    "J12": ParcelStatus.AT_PICKUP_POINT,
+    "A80": ParcelStatus.DELIVERED,
+    "I01": ParcelStatus.DELIVERED,
+    "I02": ParcelStatus.DELIVERED,
+    "I05": ParcelStatus.DELIVERED,
 }
 
-# Known notification / admin / data events that are NOT a movement milestone.
-# PostNL interleaves these throughout the timeline (often out of order), so
-# mapping them to a movement status makes the history bounce back and forth
-# (e.g. an "ETA gewijzigd" right after "Bezorger is onderweg" would otherwise
-# drag the status from out_for_delivery back to in_transit). They resolve to
-# ``status: null`` — known, so no "unrecognised" warning — while the exact
-# label is preserved on ``raw_status``.
 _OBSERVATION_META_CODES: frozenset[str] = frozenset({
-    "A04",  # PIOS melding (notification)
-    "A18",  # ETA initieel bepaald
-    "A19",  # ETA gewijzigd
-    "A25",  # reminderservice notificaties
-    "A65",  # zending herpland (planning change)
-    "A94",  # zelf bezorging gewijzigd
-    "A95",  # bezorging wijzigen niet mogelijk
-    "A96",  # bezorging wijzigen mogelijk
-    "A98",  # voorgemelde zending verrijkt door PostNL regie (data enrichment)
-    "K33",  # "leeg" placeholder
+    "A04",
+    "A18",
+    "A19",
+    "A25",
+    "A65",
+    "A94",
+    "A95",
+    "A96",
+    "A98",
+    "K33",
 })
 
-# New-issue link surfaced in the unknown-status warnings so users can paste a
-# ready-made line into a bug report.
 _NEW_ISSUE_URL = "https://github.com/peternijssen/ha-postnl/issues/new"
 
-# One-shot dedupe sets so each distinct unmapped value warns once per HA
-# session rather than on every poll.
 _LOGGED_UNKNOWN_STATUSES: set[str] = set()
 _LOGGED_UNKNOWN_OBSERVATION_CODES: set[str] = set()
 
 
 def _refresh_interval(entry: ConfigEntry) -> timedelta:
-    """Return the configured refresh interval from the config entry options."""
-    minutes = int(
-        entry.options.get(CONF_REFRESH_INTERVAL, DEFAULT_REFRESH_INTERVAL)
-    )
+    minutes = int(entry.options.get(CONF_REFRESH_INTERVAL, DEFAULT_REFRESH_INTERVAL))
     return timedelta(minutes=minutes)
 
 
 def map_parcel_status(parcel: dict) -> ParcelStatus:
-    """Map a PostNL parcel dict to a canonical :class:`ParcelStatus`.
-
-    ``parcel`` is the intermediate dict built by :meth:`transform_shipment`
-    with at least ``delivered`` (bool) and ``status_message`` (str) populated.
-    The ``delivered`` flag from GraphQL is authoritative and short-circuits to
-    :attr:`ParcelStatus.DELIVERED`. Anything that does not match any pattern
-    is reported as :attr:`ParcelStatus.UNKNOWN` and surfaced once at info
-    level so users can open an issue to extend the map.
-    """
     if parcel.get("delivered"):
         return ParcelStatus.DELIVERED
 
@@ -167,34 +122,20 @@ def map_parcel_status(parcel: dict) -> ParcelStatus:
     return ParcelStatus.UNKNOWN
 
 
-def map_observation_status(
-    code: str | None, description: str | None = None
-) -> ParcelStatus | None:
-    """Map a Track & Trace ``observationCode`` to a canonical milestone status.
-
-    Returns a :class:`ParcelStatus` only for genuine movement milestones.
-    Known notification/admin codes (:data:`_OBSERVATION_META_CODES`) and
-    unmapped codes both return ``None``; meta codes do so silently, while an
-    unmapped code surfaces a one-shot warning with copy-paste issue text so
-    users can help extend the map. :func:`build_history` decides what a
-    ``None`` becomes (carry the previous stage forward for meta, leave null
-    for unknown).
-    """
-    if not code:
+def map_observation_status(code: str | None, description: str | None) -> ParcelStatus | None:
+    if code is None:
+        return None
+    if code in _OBSERVATION_META_CODES:
         return None
     status = _OBSERVATION_CODE_MAP.get(code)
     if status is not None:
         return status
-
-    if code in _OBSERVATION_META_CODES:
-        return None  # known notification/admin event — no own movement status
-
     if code not in _LOGGED_UNKNOWN_OBSERVATION_CODES:
         _LOGGED_UNKNOWN_OBSERVATION_CODES.add(code)
         _LOGGER.warning(
-            "Unrecognised PostNL status — help us map it. Open an issue and "
-            "paste this line: %s\n  [history] observationCode=%s text=%r "
-            "→ reported as 'unknown'",
+            "Unrecognised PostNL observation code — help us map it. Open an "
+            "issue and paste this line: %s\n  [history] observationCode=%r "
+            "description=%r → status omitted from timeline",
             _NEW_ISSUE_URL,
             code,
             description,
@@ -202,85 +143,9 @@ def map_observation_status(
     return None
 
 
-def _extract_observations(colli: dict) -> list[dict]:
-    """Return the status-event list from a colli object, oldest-first preferred.
-
-    ``analyticsInfo.allObservations`` carries the **complete** timeline
-    (oldest-first); the top-level ``observations`` list is truncated to the
-    most recent few. Prefer the former, fall back to the latter.
-    """
-    analytics = colli.get("analyticsInfo") or {}
-    return analytics.get("allObservations") or colli.get("observations") or []
-
-
-def build_history(
-    observations: list[dict] | None, *, max_events: int = HISTORY_MAX_EVENTS
-) -> list[dict]:
-    """Build the canonical ``history`` list from raw Track & Trace observations.
-
-    Each entry is ``{timestamp, status, raw_status}`` — identical across all
-    suite carriers. Sorted oldest → newest by timestamp (entries with an
-    unparseable timestamp keep their original order, after the parseable ones)
-    and capped to the most recent ``max_events``.
-
-    PostNL interleaves notification/admin events (ETA recalcs, "bezorging
-    wijzigen mogelijk", data enrichment, …) throughout the timeline, often out
-    of order. Those carry **no movement status of their own**; instead they
-    inherit the stage of the most recent milestone (carry-forward), so the
-    timeline never bounces backwards on a cosmetic event — e.g. an "ETA
-    gewijzigd" logged the moment the courier sets off reads ``out_for_delivery``,
-    while the same code earlier (just after sorting) reads ``in_transit``.
-    Genuine milestones drive the status and only a real delivery delay (G/T)
-    steps back to ``in_transit``. Unmapped codes stay ``null`` (+ warning).
-    """
-    parseable: list[tuple[datetime, tuple]] = []
-    unparseable: list[tuple] = []
-    for obs in observations or []:
-        timestamp = obs.get("observationDate")
-        if not timestamp:
-            continue
-        record = (timestamp, obs.get("observationCode"), obs.get("description"))
-        dt = _parse_iso(timestamp)
-        if dt is None:
-            unparseable.append(record)
-        else:
-            parseable.append((dt, record))
-    parseable.sort(key=lambda item: item[0])
-    ordered = [record for _, record in parseable] + unparseable
-
-    history: list[dict] = []
-    # A parcel that appears in track-trace has, at minimum, been pre-announced,
-    # so the implicit baseline stage is REGISTERED. This is what a meta event
-    # (e.g. "Voorgemelde zending verrijkt") inherits when it lands before the
-    # first real milestone, instead of showing a bare null.
-    last_status: ParcelStatus | None = ParcelStatus.REGISTERED
-    for timestamp, code, description in ordered:
-        status = map_observation_status(code, description)
-        if status is not None:
-            last_status = status
-        elif code in _OBSERVATION_META_CODES:
-            # Known notification/admin event — show the stage the parcel was
-            # already in rather than inventing a (backwards) movement.
-            status = last_status
-        # else: unmapped → leave None (map_observation_status already warned)
-        history.append(
-            {"timestamp": timestamp, "status": status, "raw_status": description}
-        )
-    return history[-max_events:]
-
-
 def _convert_native_dimensions(
     native: dict | None,
 ) -> tuple[float | None, dict | None]:
-    """Convert PostNL's native dimensions (g + mm) to the suite-wide canonical
-    shape (kg + cm with a pre-formatted ``text`` string).
-
-    PostNL ships ``{height, width, depth, weight}`` in grams + millimetres,
-    and calls the long edge ``depth`` rather than ``length``. The canonical
-    contract every other carrier in the suite honours is kg + cm + ``length``,
-    with a pre-formatted ``"L x W x H cm"`` string under ``text`` so dashboard
-    cards can render it directly.
-    """
     if not native:
         return None, None
     weight_g = native.get("weight")
@@ -303,18 +168,6 @@ def _convert_native_dimensions(
 
 
 def normalize_parcel(parcel: dict, *, history: list[dict] | None = None) -> dict:
-    """Wrap a transformed PostNL parcel in the canonical carrier-agnostic shape.
-
-    Top-level keys mirror DHL / DPD / parcel-aggregator. The original
-    transformed PostNL payload (GraphQL + Track & Trace fields like
-    ``status_message``, ``delivery_address_type``, ``planned_date``,
-    ``expected_datetime`` and the native ``dimensions`` dict in g + mm)
-    is preserved under ``raw`` for power users.
-
-    ``history`` is the optional per-parcel status timeline (opt-in option,
-    default off → ``None``). It stays top-level so it survives the
-    aggregator's ``strip_raw()`` and flows through unchanged.
-    """
     delivered = bool(parcel.get("delivered"))
     weight_kg, canonical_dimensions = _convert_native_dimensions(
         parcel.get("dimensions")
@@ -341,11 +194,6 @@ def normalize_parcel(parcel: dict, *, history: list[dict] | None = None) -> dict
 
 
 def _parse_iso(value: str | None) -> datetime | None:
-    """Parse an ISO 8601 string to an aware datetime, or ``None`` on failure.
-
-    PostNL mixes offset-aware and naive timestamps in the same payload; naive
-    values are treated as UTC so a mixed list still sorts without crashing.
-    """
     if not value:
         return None
     try:
@@ -358,19 +206,12 @@ def _parse_iso(value: str | None) -> datetime | None:
 
 
 def _delivery_dt(parcel: dict) -> datetime | None:
-    """Parse the delivery datetime from a normalised parcel dict."""
     return _parse_iso(parcel.get("delivered_at"))
 
 
 def sort_parcels_by_ts(
     parcels: list[dict], key_field: str, *, descending: bool = False
 ) -> list[dict]:
-    """Return normalised parcels sorted by the ISO timestamp at ``key_field``.
-
-    Parcels whose value is missing or unparseable always sort to the end,
-    regardless of ``descending`` — so freshly registered parcels without
-    an ETA stay visible at the bottom instead of jumping to the top.
-    """
     with_ts: list[tuple[datetime, dict]] = []
     without_ts: list[dict] = []
     for parcel in parcels:
@@ -383,13 +224,48 @@ def sort_parcels_by_ts(
         except ValueError:
             without_ts.append(parcel)
             continue
-        # PostNL mixes offset-aware and naive timestamps in the same payload;
-        # treat naive values as UTC so the sort doesn't crash on a mixed list.
         if dt.tzinfo is None:
             dt = dt.replace(tzinfo=timezone.utc)
         with_ts.append((dt, parcel))
     with_ts.sort(key=lambda item: item[0], reverse=descending)
     return [p for _, p in with_ts] + without_ts
+
+
+def _extract_observations(colli: dict) -> list[dict]:
+    analytics = colli.get("analyticsInfo") or {}
+    return analytics.get("allObservations") or colli.get("observations") or []
+
+
+def build_history(
+    observations: list[dict] | None, *, max_events: int = HISTORY_MAX_EVENTS
+) -> list[dict]:
+    parseable: list[tuple[datetime, tuple]] = []
+    unparseable: list[tuple] = []
+    for obs in observations or []:
+        timestamp = obs.get("observationDate")
+        if not timestamp:
+            continue
+        record = (timestamp, obs.get("observationCode"), obs.get("description"))
+        dt = _parse_iso(timestamp)
+        if dt is None:
+            unparseable.append(record)
+        else:
+            parseable.append((dt, record))
+    parseable.sort(key=lambda item: item[0])
+    ordered = [record for _, record in parseable] + unparseable
+
+    history: list[dict] = []
+    last_status: ParcelStatus | None = ParcelStatus.REGISTERED
+    for timestamp, code, description in ordered:
+        status = map_observation_status(code, description)
+        if status is not None:
+            last_status = status
+        elif code in _OBSERVATION_META_CODES:
+            status = last_status
+        history.append(
+            {"timestamp": timestamp, "status": status, "raw_status": description}
+        )
+    return history[-max_events:]
 
 
 _DUTCH_MONTHS = {
@@ -400,12 +276,6 @@ _DUTCH_MONTHS = {
 
 
 def parse_letter_date(title: str, *, today: datetime | None = None) -> str | None:
-    """Convert a Dutch day-month title like '16 juni' into an ISO date string.
-
-    The MyMail endpoint returns dates without a year. We infer the year from
-    ``today``: if the parsed month/day is more than 31 days ahead of today, it
-    must belong to the previous year (PostNL only retains 2 weeks of mail).
-    """
     if not title:
         return None
     parts = title.strip().lower().split()
@@ -432,7 +302,6 @@ def parse_letter_date(title: str, *, today: datetime | None = None) -> str | Non
 
 
 def extract_letters(payload: dict, *, today: datetime | None = None) -> list[dict]:
-    """Extract letter entries from the server-driven-UI MyMail response."""
     sections = ((payload or {}).get("screen") or {}).get("sections") or []
     letters: list[dict] = []
     for section in sections:
@@ -463,62 +332,21 @@ class PostNLCoordinator(DataUpdateCoordinator):
             update_interval=_refresh_interval(entry),
         )
         self.delivered_receiver: list[dict] = []
+        self.delivered_sender: list[dict] = []
         self.letters: list[dict] = []
-        # API clients are reused across polls (each PostNLJouwAPI owns a
-        # requests.Session with a connection pool); they are only rebuilt
-        # when the access token actually changes.
         self.graphq_api: PostNLGraphql | None = None
         self.jouw_api: PostNLJouwAPI | None = None
         self._api_token: str | None = None
-        # barcode -> last seen ParcelStatus. ``None`` on the first refresh so
-        # we can suppress events for parcels that already existed when the
-        # integration started (we do not know their previous state).
         self._known_state: dict[str, ParcelStatus] | None = None
-        # barcode -> last seen (planned_from, planned_to) tuple. Mirrors
-        # ``_known_state`` for delivery-time-change detection.
         self._known_delivery_times: (
             dict[str, tuple[str | None, str | None]] | None
         ) = None
-        # Letter ids seen on the previous successful letters fetch. ``None``
-        # on the first refresh for the same reason — we do not want to fire
-        # ``postnl_letter_announced`` for every letter that already existed.
         self._known_letter_ids: set[str] | None = None
-        # barcode -> last successfully transformed (normalized) parcel, so a
-        # transient Track & Trace failure for one parcel degrades to its
-        # previous data instead of failing the whole refresh.
         self._parcel_cache: dict[str, dict] = {}
-        # barcode -> history timeline for *delivered* parcels. A delivered
-        # parcel's history never changes, so the extra T&T call is made at
-        # most once per barcode instead of on every poll.
         self._delivered_history_cache: dict[str, list[dict] | None] = {}
-        # Cached device id for this account, attached to every fired event so
-        # device-trigger automations can filter to a specific PostNL account.
-        # ``None`` until the device exists (i.e. the sensors are set up).
         self._cached_device_id: str | None = None
-        # Timestamp of the last successful poll, surfaced by a diagnostic
-        # sensor so users can alert on a silently-stale integration (the
-        # count sensors only change when a value changes, not every poll).
         self.last_success_time: datetime | None = None
         _LOGGER.debug("PostNLCoordinator initialized with update interval: %s", self.update_interval)
-
-    def _device_id(self) -> str | None:
-        """Resolve (and cache) this account's device id for event payloads.
-
-        Looked up from the device registry by config entry. Stays ``None``
-        until the device has been registered (the sensors create it on first
-        setup), which is harmless because events are suppressed on the very
-        first refresh anyway.
-        """
-        if self._cached_device_id is not None:
-            return self._cached_device_id
-        registry = dr.async_get(self.hass)
-        device = next(
-            iter(dr.async_entries_for_config_entry(registry, self.config_entry.entry_id)),
-            None,
-        )
-        if device is not None:
-            self._cached_device_id = device.id
-        return self._cached_device_id
 
     async def _async_update_data(self) -> dict[str, list[dict]]:
         _LOGGER.debug("Starting data update for PostNL.")
@@ -551,8 +379,6 @@ class PostNLCoordinator(DataUpdateCoordinator):
             data['receiver'] = sort_parcels_by_ts(data['receiver'], 'planned_from')
             data['sender'] = sort_parcels_by_ts(data['sender'], 'planned_from')
 
-            # Keep the fallback/history caches bounded to barcodes PostNL
-            # still reports; anything older can never be needed again.
             current_barcodes = {
                 p.get('barcode') for p in data['receiver'] if p.get('barcode')
             }
@@ -585,6 +411,13 @@ class PostNLCoordinator(DataUpdateCoordinator):
                 descending=True,
             )
 
+            delivered_sender = [p for p in data['sender'] if p.get('delivered')]
+            self.delivered_sender = sort_parcels_by_ts(
+                self._apply_delivered_filter(delivered_sender),
+                'delivered_at',
+                descending=True,
+            )
+
             try:
                 letters_payload = await self.hass.async_add_executor_job(self.jouw_api.letters)
                 self.letters = extract_letters(letters_payload)
@@ -610,17 +443,6 @@ class PostNLCoordinator(DataUpdateCoordinator):
             raise UpdateFailed("Unable to update PostNL data") from exception
 
     def _fire_change_events(self, parcels: list[dict]) -> None:
-        """Fire events for newly-registered parcels and parcel transitions.
-
-        Silent on the very first refresh — we cannot reliably know which
-        parcels are "new" to the user vs. "already there before HA started".
-        From the second refresh onward, every parcel that was not present
-        before yields one ``postnl_parcel_registered`` event, every parcel
-        whose normalised status changed yields one
-        ``postnl_parcel_status_changed`` event, and every parcel whose
-        ``planned_from`` or ``planned_to`` changed to a non-null value
-        yields one ``postnl_parcel_delivery_time_changed`` event.
-        """
         if self._known_state is None:
             return
 
@@ -653,11 +475,6 @@ class PostNLCoordinator(DataUpdateCoordinator):
             old_from, old_to = known_times.get(barcode, (None, None))
             new_from = parcel.get("planned_from")
             new_to = parcel.get("planned_to")
-            # Fire only when at least one of the two ends up with a real
-            # (non-null) value AND that value differs from the last-known
-            # one. value -> null transitions are intentionally silent —
-            # they mean the carrier dropped the ETA, which is not what
-            # users want to be paged about.
             from_changed = new_from is not None and new_from != old_from
             to_changed = new_to is not None and new_to != old_to
             if from_changed or to_changed:
@@ -674,14 +491,6 @@ class PostNLCoordinator(DataUpdateCoordinator):
                 )
 
     def _fire_letter_events(self, letters: list[dict]) -> None:
-        """Fire ``postnl_letter_announced`` for newly-seen letter ids.
-
-        Silent on the very first refresh — we cannot tell which letters
-        are "new" vs "already announced before HA started". From the
-        second refresh onward, every letter whose id was not present in
-        the previous successful fetch yields one event with the full
-        letter payload plus ``carrier: "PostNL"``.
-        """
         if self._known_letter_ids is None:
             return
         device_id = self._device_id()
@@ -695,7 +504,6 @@ class PostNLCoordinator(DataUpdateCoordinator):
             )
 
     def _apply_delivered_filter(self, parcels: list[dict]) -> list[dict]:
-        """Trim the delivered receiver list according to the configured options."""
         options = self.config_entry.options
         filter_type = options.get(CONF_DELIVERED_FILTER_TYPE, DEFAULT_DELIVERED_FILTER_TYPE)
         filter_amount = int(options.get(CONF_DELIVERED_FILTER_AMOUNT, DEFAULT_DELIVERED_FILTER_AMOUNT))
@@ -708,25 +516,11 @@ class PostNLCoordinator(DataUpdateCoordinator):
 
     @property
     def _include_history(self) -> bool:
-        """Whether the opt-in per-parcel history option is enabled."""
         return bool(
-            self.config_entry.options.get(
-                CONF_INCLUDE_HISTORY, DEFAULT_INCLUDE_HISTORY
-            )
+            self.config_entry.options.get(CONF_INCLUDE_HISTORY, DEFAULT_INCLUDE_HISTORY)
         )
 
     def _delivered_history(self, shipment) -> list[dict] | None:
-        """Fetch a history timeline for a delivered shipment (opt-in only).
-
-        The active path gets observations from the Track & Trace call it
-        already makes, but delivered parcels normally skip that call. When the
-        history option is on we make the extra call here so delivered parcels
-        get parity with DHL / DPD. A delivered parcel's history never changes,
-        so a successful fetch is cached per barcode — one call per parcel
-        ever, not one per poll. A failure is non-fatal — history is a
-        nice-to-have, so we log and fall back to ``None`` (uncached, so the
-        next poll retries) rather than failing the whole refresh.
-        """
         if not self._include_history:
             return None
         barcode = shipment.get('barcode')
@@ -746,6 +540,18 @@ class PostNLCoordinator(DataUpdateCoordinator):
             self._delivered_history_cache[barcode] = history
         return history
 
+    def _device_id(self) -> str | None:
+        if self._cached_device_id is not None:
+            return self._cached_device_id
+        registry = dr.async_get(self.hass)
+        device = next(
+            iter(dr.async_entries_for_config_entry(registry, self.config_entry.entry_id)),
+            None,
+        )
+        if device is not None:
+            self._cached_device_id = device.id
+        return self._cached_device_id
+
     async def transform_shipment(self, shipment) -> dict:
         _LOGGER.debug('Updating %s', shipment.get('key'))
 
@@ -755,12 +561,6 @@ class PostNLCoordinator(DataUpdateCoordinator):
             if shipment.get('delivered'):
                 _LOGGER.debug('%s already delivered, no need to call jouw.postnl.', shipment.get('key'))
 
-                # Delivered short-circuits the Track & Trace call, so there's no
-                # ``colli.recipient.names.personName`` to read — the GraphQL
-                # ``receiverTitle`` is the equivalent. No weight/dimensions
-                # available on this path; the suite contract accepts those as
-                # ``None``. History is the one exception: when the opt-in
-                # option is on we make an extra T&T call for the timeline.
                 history = await self.hass.async_add_executor_job(
                     self._delivered_history, shipment
                 )
@@ -794,9 +594,6 @@ class PostNLCoordinator(DataUpdateCoordinator):
                     self.jouw_api.track_and_trace, shipment['key']
                 )
             except requests.exceptions.RequestException as exception:
-                # One broken T&T call must not fail the whole refresh. Degrade
-                # per parcel: reuse the last successful transform when we have
-                # one, otherwise fall through with the GraphQL-only fields.
                 barcode = shipment.get('barcode')
                 cached = self._parcel_cache.get(barcode) if barcode else None
                 if cached is not None:
@@ -845,8 +642,6 @@ class PostNLCoordinator(DataUpdateCoordinator):
                     colli.get('recipient', {}).get('names', {}).get('personName')
                 )
                 native_dimensions = (colli.get('details') or {}).get('dimensions')
-                # The active T&T call already carries the timeline; only build
-                # it when the opt-in option is on.
                 history = (
                     build_history(_extract_observations(colli))
                     if self._include_history
@@ -865,10 +660,6 @@ class PostNLCoordinator(DataUpdateCoordinator):
                 "url": shipment.get('detailsUrl'),
                 "shipment_type": shipment.get('shipmentType'),
                 "receiver_title": receiver_title,
-                # ``recipient.personName`` from Track & Trace is the
-                # authoritative recipient name on the active path;
-                # ``receiverTitle`` is the GraphQL fallback for when T&T
-                # doesn't have it yet (first poll after registration).
                 "receiver": recipient_name or receiver_title,
                 "source_display_name": (
                         (shipment.get('sourceDisplayName') or '').strip()
@@ -883,22 +674,13 @@ class PostNLCoordinator(DataUpdateCoordinator):
                 "planned_from": planned_from,
                 "planned_to": planned_to,
                 "expected_datetime": expected_datetime,
-                # Native PostNL dimensions (g + mm). Lives on the
-                # intermediate dict so it surfaces under ``raw`` for power
-                # users; ``normalize_parcel`` reads it and produces the
-                # canonical kg + cm + ``text`` shape at the top level.
                 "dimensions": native_dimensions,
             }, history=history)
             barcode = shipment.get('barcode')
             if barcode and colli:
-                # Only a transform backed by real T&T data is worth reusing
-                # as a fallback on a later transient failure.
                 self._parcel_cache[barcode] = parcel
             return parcel
         except requests.exceptions.RequestException as exception:
-            # Safety net for requests errors outside the targeted T&T catch.
-            # Degrade to the last successful transform when we have one; only
-            # fail the refresh when there is nothing to show for this parcel.
             _LOGGER.error("Error fetching Track and Trace details for shipment %s: %s", shipment.get('key'), exception, exc_info=True)
             barcode = shipment.get('barcode')
             cached = self._parcel_cache.get(barcode) if barcode else None

--- a/custom_components/postnl/icons.json
+++ b/custom_components/postnl/icons.json
@@ -23,6 +23,9 @@
       "delivered_parcels": {
         "default": "mdi:package-variant"
       },
+      "outgoing_delivered_parcels": {
+        "default": "mdi:package-variant"
+      },
       "next_delivery": {
         "default": "mdi:clock-fast"
       },

--- a/custom_components/postnl/sensor.py
+++ b/custom_components/postnl/sensor.py
@@ -48,7 +48,7 @@ async def async_setup_entry(
         f"{account_id}_en_route_to_service_point",
         f"{account_id}_outgoing_parcels",
         f"{account_id}_delivered_parcels",
-		f"{account_id}_outgoing_delivered_parcels",
+        f"{account_id}_outgoing_delivered_parcels",
         f"{account_id}_letters",
         f"{account_id}_last_update",
     }
@@ -76,7 +76,7 @@ async def async_setup_entry(
         PostNLEnRouteToServicePointSensor(coordinator=coordinator, userinfo=userinfo),
         PostNLOutgoingParcelsSensor(coordinator=coordinator, userinfo=userinfo),
         PostNLDeliveredParcelsSensor(coordinator=coordinator, userinfo=userinfo),
-		PostNLDeliveredSenderSensor(coordinator=coordinator, userinfo=userinfo),
+        PostNLOutgoingDeliveredParcelsSensor(coordinator=coordinator, userinfo=userinfo),
         PostNLLettersSensor(coordinator=coordinator, userinfo=userinfo),
         PostNLLastUpdateSensor(coordinator=coordinator, userinfo=userinfo),
     ]
@@ -358,7 +358,7 @@ class PostNLDeliveredParcelsSensor(CoordinatorEntity[PostNLCoordinator], SensorE
         return {"parcels": self._parcels}
 
 
-class PostNLDeliveredSenderSensor(CoordinatorEntity[PostNLCoordinator], SensorEntity):
+class PostNLOutgoingDeliveredParcelsSensor(CoordinatorEntity[PostNLCoordinator], SensorEntity):
     """Sensor reporting recently delivered outgoing PostNL parcels."""
 
     _attr_has_entity_name = True
@@ -376,9 +376,6 @@ class PostNLDeliveredSenderSensor(CoordinatorEntity[PostNLCoordinator], SensorEn
         account_id: str = userinfo.get("account_id", "")
         self._attr_unique_id = f"{account_id}_outgoing_delivered_parcels"
         self._attr_device_info = _build_device_info(userinfo)
-        # Pin the entity_id to the English key so it stays language-independent
-        # regardless of the HA UI language at first-creation time.
-        self.entity_id = f"sensor.{account_id}_postnl_outgoing_delivered_parcels"
 
     @property
     def _parcels(self) -> list[dict]:

--- a/custom_components/postnl/sensor.py
+++ b/custom_components/postnl/sensor.py
@@ -48,6 +48,7 @@ async def async_setup_entry(
         f"{account_id}_en_route_to_service_point",
         f"{account_id}_outgoing_parcels",
         f"{account_id}_delivered_parcels",
+        f"{account_id}_outgoing_delivered_parcels",
         f"{account_id}_letters",
         f"{account_id}_last_update",
     }
@@ -75,6 +76,7 @@ async def async_setup_entry(
         PostNLEnRouteToServicePointSensor(coordinator=coordinator, userinfo=userinfo),
         PostNLOutgoingParcelsSensor(coordinator=coordinator, userinfo=userinfo),
         PostNLDeliveredParcelsSensor(coordinator=coordinator, userinfo=userinfo),
+        PostNLDeliveredSenderSensor(coordinator=coordinator, userinfo=userinfo),
         PostNLLettersSensor(coordinator=coordinator, userinfo=userinfo),
         PostNLLastUpdateSensor(coordinator=coordinator, userinfo=userinfo),
     ]
@@ -108,11 +110,7 @@ class PostNLIncomingParcelsSensor(CoordinatorEntity[PostNLCoordinator], SensorEn
 
     Spawns a per-parcel :class:`PostNLParcelSensor` whenever a new barcode
     appears, and removes the per-parcel sensor from the entity registry
-    when its barcode drops out of the coordinator data. Doing the removal
-    here (synchronously, via the registry) instead of having the per-parcel
-    sensor self-remove from inside its own ``_handle_coordinator_update``
-    avoids the race where ``async_remove(force_remove=True)`` competes with
-    the coordinator-listener cleanup and leaves a ghost entity behind.
+    when its barcode drops out of the coordinator data.
     """
 
     _attr_has_entity_name = True
@@ -209,7 +207,6 @@ class PostNLParcelSensor(CoordinatorEntity[PostNLCoordinator], SensorEntity):
     def extra_state_attributes(self) -> dict[str, Any]:
         parcel = self._get_parcel()
         return dict(parcel) if parcel else {}
-
 
 
 class PostNLNextDeliverySensor(CoordinatorEntity[PostNLCoordinator], SensorEntity):
@@ -356,6 +353,41 @@ class PostNLDeliveredParcelsSensor(CoordinatorEntity[PostNLCoordinator], SensorE
         return {"parcels": self._parcels}
 
 
+class PostNLDeliveredSenderSensor(CoordinatorEntity[PostNLCoordinator], SensorEntity):
+    """Sensor reporting recently delivered outgoing PostNL parcels."""
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "outgoing_delivered_parcels"
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_attribution = "Data provided by PostNL"
+    _unrecorded_attributes = frozenset({"parcels"})
+
+    def __init__(
+        self,
+        coordinator: PostNLCoordinator,
+        userinfo: dict[str, Any],
+    ) -> None:
+        super().__init__(coordinator)
+        account_id: str = userinfo.get("account_id", "")
+        self._attr_unique_id = f"{account_id}_outgoing_delivered_parcels"
+        self._attr_device_info = _build_device_info(userinfo)
+        # Pin the entity_id to the English key so it stays language-independent
+        # regardless of the HA UI language at first-creation time.
+        self.entity_id = f"sensor.{account_id}_postnl_outgoing_delivered_parcels"
+
+    @property
+    def _parcels(self) -> list[dict]:
+        return self.coordinator.delivered_sender or []
+
+    @property
+    def native_value(self) -> int:
+        return len(self._parcels)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        return {"parcels": self._parcels}
+
+
 class PostNLLettersSensor(CoordinatorEntity[PostNLCoordinator], SensorEntity):
     """Sensor reporting letters announced by PostNL's MyMail service."""
 
@@ -392,12 +424,7 @@ class PostNLLettersSensor(CoordinatorEntity[PostNLCoordinator], SensorEntity):
 
 
 class PostNLLastUpdateSensor(CoordinatorEntity[PostNLCoordinator], SensorEntity):
-    """Diagnostic sensor reporting when PostNL was last polled successfully.
-
-    Updates on every successful coordinator refresh, even when no parcel
-    value changes — so users can alert on a silently-stale integration
-    (e.g. expired auth) that the count sensors would not reveal.
-    """
+    """Diagnostic sensor reporting when PostNL was last polled successfully."""
 
     _attr_has_entity_name = True
     _attr_translation_key = "last_update"
@@ -417,5 +444,4 @@ class PostNLLastUpdateSensor(CoordinatorEntity[PostNLCoordinator], SensorEntity)
 
     @property
     def native_value(self) -> datetime | None:
-        """Return the timestamp of the last successful poll."""
         return self.coordinator.last_success_time

--- a/custom_components/postnl/sensor.py
+++ b/custom_components/postnl/sensor.py
@@ -48,7 +48,7 @@ async def async_setup_entry(
         f"{account_id}_en_route_to_service_point",
         f"{account_id}_outgoing_parcels",
         f"{account_id}_delivered_parcels",
-        f"{account_id}_outgoing_delivered_parcels",
+		f"{account_id}_outgoing_delivered_parcels",
         f"{account_id}_letters",
         f"{account_id}_last_update",
     }
@@ -76,7 +76,7 @@ async def async_setup_entry(
         PostNLEnRouteToServicePointSensor(coordinator=coordinator, userinfo=userinfo),
         PostNLOutgoingParcelsSensor(coordinator=coordinator, userinfo=userinfo),
         PostNLDeliveredParcelsSensor(coordinator=coordinator, userinfo=userinfo),
-        PostNLDeliveredSenderSensor(coordinator=coordinator, userinfo=userinfo),
+		PostNLDeliveredSenderSensor(coordinator=coordinator, userinfo=userinfo),
         PostNLLettersSensor(coordinator=coordinator, userinfo=userinfo),
         PostNLLastUpdateSensor(coordinator=coordinator, userinfo=userinfo),
     ]
@@ -110,7 +110,11 @@ class PostNLIncomingParcelsSensor(CoordinatorEntity[PostNLCoordinator], SensorEn
 
     Spawns a per-parcel :class:`PostNLParcelSensor` whenever a new barcode
     appears, and removes the per-parcel sensor from the entity registry
-    when its barcode drops out of the coordinator data.
+    when its barcode drops out of the coordinator data. Doing the removal
+    here (synchronously, via the registry) instead of having the per-parcel
+    sensor self-remove from inside its own ``_handle_coordinator_update``
+    avoids the race where ``async_remove(force_remove=True)`` competes with
+    the coordinator-listener cleanup and leaves a ghost entity behind.
     """
 
     _attr_has_entity_name = True
@@ -207,6 +211,7 @@ class PostNLParcelSensor(CoordinatorEntity[PostNLCoordinator], SensorEntity):
     def extra_state_attributes(self) -> dict[str, Any]:
         parcel = self._get_parcel()
         return dict(parcel) if parcel else {}
+
 
 
 class PostNLNextDeliverySensor(CoordinatorEntity[PostNLCoordinator], SensorEntity):
@@ -424,7 +429,12 @@ class PostNLLettersSensor(CoordinatorEntity[PostNLCoordinator], SensorEntity):
 
 
 class PostNLLastUpdateSensor(CoordinatorEntity[PostNLCoordinator], SensorEntity):
-    """Diagnostic sensor reporting when PostNL was last polled successfully."""
+    """Diagnostic sensor reporting when PostNL was last polled successfully.
+
+    Updates on every successful coordinator refresh, even when no parcel
+    value changes — so users can alert on a silently-stale integration
+    (e.g. expired auth) that the count sensors would not reveal.
+    """
 
     _attr_has_entity_name = True
     _attr_translation_key = "last_update"
@@ -444,4 +454,5 @@ class PostNLLastUpdateSensor(CoordinatorEntity[PostNLCoordinator], SensorEntity)
 
     @property
     def native_value(self) -> datetime | None:
+        """Return the timestamp of the last successful poll."""
         return self.coordinator.last_success_time

--- a/custom_components/postnl/strings.json
+++ b/custom_components/postnl/strings.json
@@ -130,6 +130,10 @@
         "name": "Delivered parcels",
         "unit_of_measurement": "parcels"
       },
+      "outgoing_delivered_parcels": {
+        "name": "Delivered outgoing parcels",
+        "unit_of_measurement": "parcels"
+      },
       "next_delivery": {
         "name": "Next delivery"
       },

--- a/custom_components/postnl/strings.json
+++ b/custom_components/postnl/strings.json
@@ -131,7 +131,7 @@
         "unit_of_measurement": "parcels"
       },
       "outgoing_delivered_parcels": {
-        "name": "Delivered outgoing parcels",
+        "name": "Outgoing delivered parcels",
         "unit_of_measurement": "parcels"
       },
       "next_delivery": {

--- a/custom_components/postnl/translations/en.json
+++ b/custom_components/postnl/translations/en.json
@@ -22,7 +22,7 @@
         }
       },
       "reauth_confirm": {
-        "title": "Re-authenticate PostNL",
+        "title": "PostNL — re-authentication required",
         "description": "Your PostNL session has expired. Please enter your credentials again.",
         "data": {
           "username": "Email address",
@@ -31,63 +31,30 @@
       }
     },
     "error": {
-      "invalid_auth": "Invalid email or password.",
-      "cannot_connect": "Unable to reach PostNL. Check your network."
+      "invalid_auth": "Invalid email address or password.",
+      "cannot_connect": "Unable to connect to PostNL. Please try again."
     },
     "abort": {
-      "already_configured": "This PostNL account is already configured.",
-      "reauth_successful": "Re-authentication successful.",
-      "unique_id_mismatch": "Re-authenticate with the same PostNL account this entry was set up with."
+      "already_configured": "This account is already configured.",
+      "reauth_successful": "Re-authentication was successful."
     }
   },
   "options": {
     "step": {
       "init": {
-        "title": "PostNL options",
-        "sections": {
-          "delivered": {
-            "name": "Delivered parcels",
-            "data": {
-              "delivered_filter_type": "Filter by",
-              "delivered_filter_amount": "Amount"
-            },
-            "data_description": {
-              "delivered_filter_type": "Show delivered parcels from the last X days, or limit to the X most recent.",
-              "delivered_filter_amount": "Number of days or parcels to show."
-            }
-          },
-          "history": {
-            "name": "Parcel history",
-            "data": {
-              "include_history": "Include status history"
-            },
-            "data_description": {
-              "include_history": "Add a per-parcel history attribute listing each status update (timestamp, status, original text). Off by default."
-            }
-          },
-          "polling": {
-            "name": "Polling",
-            "data": {
-              "refresh_interval": "Refresh every"
-            },
-            "data_description": {
-              "refresh_interval": "How often the integration checks PostNL for parcel updates. A slower interval is gentler on PostNL's API; the default of 30 minutes is plenty for most parcels."
-            }
-          }
+        "title": "Delivered parcels",
+        "data": {
+          "delivered_filter_type": "Filter by",
+          "delivered_filter_amount": "Amount"
+        },
+        "data_description": {
+          "delivered_filter_type": "Show delivered parcels from the last X days, or limit to the X most recent.",
+          "delivered_filter_amount": "Number of days or parcels to show."
         }
       }
     }
   },
   "selector": {
-    "refresh_interval": {
-      "options": {
-        "15": "15 minutes",
-        "30": "30 minutes",
-        "60": "60 minutes",
-        "120": "120 minutes",
-        "240": "240 minutes"
-      }
-    },
     "delivered_filter_type": {
       "options": {
         "days": "Days",
@@ -95,25 +62,7 @@
       }
     }
   },
-  "device_automation": {
-    "trigger_type": {
-      "parcel_registered": "A parcel was registered",
-      "parcel_status_changed": "A parcel's status changed",
-      "parcel_delivery_time_changed": "A parcel's expected delivery time changed",
-      "letter_announced": "A letter was announced"
-    }
-  },
   "entity": {
-    "button": {
-      "refresh": {
-        "name": "Refresh"
-      }
-    },
-    "calendar": {
-      "deliveries": {
-        "name": "Deliveries"
-      }
-    },
     "sensor": {
       "incoming_parcels": {
         "name": "Incoming parcels",
@@ -130,6 +79,10 @@
         "name": "Delivered parcels",
         "unit_of_measurement": "parcels"
       },
+      "outgoing_delivered_parcels": {
+        "name": "Delivered outgoing parcels",
+        "unit_of_measurement": "parcels"
+      },
       "next_delivery": {
         "name": "Next delivery"
       },
@@ -142,7 +95,7 @@
         "unit_of_measurement": "letters"
       },
       "last_update": {
-        "name": "Last successful update"
+        "name": "Last update"
       }
     },
     "image": {

--- a/custom_components/postnl/translations/en.json
+++ b/custom_components/postnl/translations/en.json
@@ -22,7 +22,7 @@
         }
       },
       "reauth_confirm": {
-        "title": "PostNL — re-authentication required",
+        "title": "Re-authenticate PostNL",
         "description": "Your PostNL session has expired. Please enter your credentials again.",
         "data": {
           "username": "Email address",
@@ -31,30 +31,63 @@
       }
     },
     "error": {
-      "invalid_auth": "Invalid email address or password.",
-      "cannot_connect": "Unable to connect to PostNL. Please try again."
+      "invalid_auth": "Invalid email or password.",
+      "cannot_connect": "Unable to reach PostNL. Check your network."
     },
     "abort": {
-      "already_configured": "This account is already configured.",
-      "reauth_successful": "Re-authentication was successful."
+      "already_configured": "This PostNL account is already configured.",
+      "reauth_successful": "Re-authentication successful.",
+      "unique_id_mismatch": "Re-authenticate with the same PostNL account this entry was set up with."
     }
   },
   "options": {
     "step": {
       "init": {
-        "title": "Delivered parcels",
-        "data": {
-          "delivered_filter_type": "Filter by",
-          "delivered_filter_amount": "Amount"
-        },
-        "data_description": {
-          "delivered_filter_type": "Show delivered parcels from the last X days, or limit to the X most recent.",
-          "delivered_filter_amount": "Number of days or parcels to show."
+        "title": "PostNL options",
+        "sections": {
+          "delivered": {
+            "name": "Delivered parcels",
+            "data": {
+              "delivered_filter_type": "Filter by",
+              "delivered_filter_amount": "Amount"
+            },
+            "data_description": {
+              "delivered_filter_type": "Show delivered parcels from the last X days, or limit to the X most recent.",
+              "delivered_filter_amount": "Number of days or parcels to show."
+            }
+          },
+          "history": {
+            "name": "Parcel history",
+            "data": {
+              "include_history": "Include status history"
+            },
+            "data_description": {
+              "include_history": "Add a per-parcel history attribute listing each status update (timestamp, status, original text). Off by default."
+            }
+          },
+          "polling": {
+            "name": "Polling",
+            "data": {
+              "refresh_interval": "Refresh every"
+            },
+            "data_description": {
+              "refresh_interval": "How often the integration checks PostNL for parcel updates. A slower interval is gentler on PostNL's API; the default of 30 minutes is plenty for most parcels."
+            }
+          }
         }
       }
     }
   },
   "selector": {
+    "refresh_interval": {
+      "options": {
+        "15": "15 minutes",
+        "30": "30 minutes",
+        "60": "60 minutes",
+        "120": "120 minutes",
+        "240": "240 minutes"
+      }
+    },
     "delivered_filter_type": {
       "options": {
         "days": "Days",
@@ -62,7 +95,25 @@
       }
     }
   },
+  "device_automation": {
+    "trigger_type": {
+      "parcel_registered": "A parcel was registered",
+      "parcel_status_changed": "A parcel's status changed",
+      "parcel_delivery_time_changed": "A parcel's expected delivery time changed",
+      "letter_announced": "A letter was announced"
+    }
+  },
   "entity": {
+    "button": {
+      "refresh": {
+        "name": "Refresh"
+      }
+    },
+    "calendar": {
+      "deliveries": {
+        "name": "Deliveries"
+      }
+    },
     "sensor": {
       "incoming_parcels": {
         "name": "Incoming parcels",
@@ -95,7 +146,7 @@
         "unit_of_measurement": "letters"
       },
       "last_update": {
-        "name": "Last update"
+        "name": "Last successful update"
       }
     },
     "image": {

--- a/custom_components/postnl/translations/en.json
+++ b/custom_components/postnl/translations/en.json
@@ -131,7 +131,7 @@
         "unit_of_measurement": "parcels"
       },
       "outgoing_delivered_parcels": {
-        "name": "Delivered outgoing parcels",
+        "name": "Outgoing delivered parcels",
         "unit_of_measurement": "parcels"
       },
       "next_delivery": {

--- a/custom_components/postnl/translations/nl.json
+++ b/custom_components/postnl/translations/nl.json
@@ -22,7 +22,7 @@
         }
       },
       "reauth_confirm": {
-        "title": "PostNL — opnieuw inloggen vereist",
+        "title": "Opnieuw inloggen bij PostNL",
         "description": "Je PostNL-sessie is verlopen. Voer je gegevens opnieuw in.",
         "data": {
           "username": "E-mailadres",
@@ -32,29 +32,62 @@
     },
     "error": {
       "invalid_auth": "Ongeldig e-mailadres of wachtwoord.",
-      "cannot_connect": "Kan geen verbinding maken met PostNL. Probeer het opnieuw."
+      "cannot_connect": "Kan PostNL niet bereiken. Controleer je netwerkverbinding."
     },
     "abort": {
-      "already_configured": "Dit account is al geconfigureerd.",
-      "reauth_successful": "Opnieuw inloggen geslaagd."
+      "already_configured": "Dit PostNL-account is al geconfigureerd.",
+      "reauth_successful": "Opnieuw inloggen geslaagd.",
+      "unique_id_mismatch": "Log opnieuw in met hetzelfde PostNL-account waarmee deze koppeling is ingesteld."
     }
   },
   "options": {
     "step": {
       "init": {
-        "title": "Bezorgde pakketten",
-        "data": {
-          "delivered_filter_type": "Filteren op",
-          "delivered_filter_amount": "Aantal"
-        },
-        "data_description": {
-          "delivered_filter_type": "Toon bezorgde pakketten van de afgelopen X dagen, of beperk tot de X meest recente.",
-          "delivered_filter_amount": "Aantal dagen of pakketten om weer te geven."
+        "title": "PostNL-opties",
+        "sections": {
+          "delivered": {
+            "name": "Bezorgde pakketten",
+            "data": {
+              "delivered_filter_type": "Filteren op",
+              "delivered_filter_amount": "Aantal"
+            },
+            "data_description": {
+              "delivered_filter_type": "Toon bezorgde pakketten van de afgelopen X dagen, of beperk tot de X meest recente.",
+              "delivered_filter_amount": "Aantal dagen of pakketten om weer te geven."
+            }
+          },
+          "history": {
+            "name": "Pakketgeschiedenis",
+            "data": {
+              "include_history": "Statusgeschiedenis toevoegen"
+            },
+            "data_description": {
+              "include_history": "Voegt een geschiedenis-attribuut per pakket toe met elke statusupdate (tijdstip, status, originele tekst). Standaard uit."
+            }
+          },
+          "polling": {
+            "name": "Verversen",
+            "data": {
+              "refresh_interval": "Ververs elke"
+            },
+            "data_description": {
+              "refresh_interval": "Hoe vaak de integratie PostNL controleert op pakketupdates. Een langzamer interval is vriendelijker voor PostNL; de standaard van 30 minuten is ruim voldoende voor de meeste pakketten."
+            }
+          }
         }
       }
     }
   },
   "selector": {
+    "refresh_interval": {
+      "options": {
+        "15": "15 minuten",
+        "30": "30 minuten",
+        "60": "60 minuten",
+        "120": "120 minuten",
+        "240": "240 minuten"
+      }
+    },
     "delivered_filter_type": {
       "options": {
         "days": "Dagen",
@@ -62,7 +95,25 @@
       }
     }
   },
+  "device_automation": {
+    "trigger_type": {
+      "parcel_registered": "Een pakket is geregistreerd",
+      "parcel_status_changed": "De status van een pakket is gewijzigd",
+      "parcel_delivery_time_changed": "De verwachte bezorgtijd van een pakket is gewijzigd",
+      "letter_announced": "Een brief is aangekondigd"
+    }
+  },
   "entity": {
+    "button": {
+      "refresh": {
+        "name": "Verversen"
+      }
+    },
+    "calendar": {
+      "deliveries": {
+        "name": "Bezorgingen"
+      }
+    },
     "sensor": {
       "incoming_parcels": {
         "name": "Inkomende pakketten",
@@ -95,7 +146,7 @@
         "unit_of_measurement": "brieven"
       },
       "last_update": {
-        "name": "Laatste update"
+        "name": "Laatste succesvolle update"
       }
     },
     "image": {

--- a/custom_components/postnl/translations/nl.json
+++ b/custom_components/postnl/translations/nl.json
@@ -131,7 +131,7 @@
         "unit_of_measurement": "pakketten"
       },
       "outgoing_delivered_parcels": {
-        "name": "Bezorgde uitgaande pakketten",
+        "name": "Uitgaande bezorgde pakketten",
         "unit_of_measurement": "pakketten"
       },
       "next_delivery": {

--- a/custom_components/postnl/translations/nl.json
+++ b/custom_components/postnl/translations/nl.json
@@ -22,7 +22,7 @@
         }
       },
       "reauth_confirm": {
-        "title": "Opnieuw inloggen bij PostNL",
+        "title": "PostNL — opnieuw inloggen vereist",
         "description": "Je PostNL-sessie is verlopen. Voer je gegevens opnieuw in.",
         "data": {
           "username": "E-mailadres",
@@ -32,62 +32,29 @@
     },
     "error": {
       "invalid_auth": "Ongeldig e-mailadres of wachtwoord.",
-      "cannot_connect": "Kan PostNL niet bereiken. Controleer je netwerkverbinding."
+      "cannot_connect": "Kan geen verbinding maken met PostNL. Probeer het opnieuw."
     },
     "abort": {
-      "already_configured": "Dit PostNL-account is al geconfigureerd.",
-      "reauth_successful": "Opnieuw inloggen geslaagd.",
-      "unique_id_mismatch": "Log opnieuw in met hetzelfde PostNL-account waarmee deze koppeling is ingesteld."
+      "already_configured": "Dit account is al geconfigureerd.",
+      "reauth_successful": "Opnieuw inloggen geslaagd."
     }
   },
   "options": {
     "step": {
       "init": {
-        "title": "PostNL-opties",
-        "sections": {
-          "delivered": {
-            "name": "Bezorgde pakketten",
-            "data": {
-              "delivered_filter_type": "Filteren op",
-              "delivered_filter_amount": "Aantal"
-            },
-            "data_description": {
-              "delivered_filter_type": "Toon bezorgde pakketten van de afgelopen X dagen, of beperk tot de X meest recente.",
-              "delivered_filter_amount": "Aantal dagen of pakketten om weer te geven."
-            }
-          },
-          "history": {
-            "name": "Pakketgeschiedenis",
-            "data": {
-              "include_history": "Statusgeschiedenis toevoegen"
-            },
-            "data_description": {
-              "include_history": "Voegt een geschiedenis-attribuut per pakket toe met elke statusupdate (tijdstip, status, originele tekst). Standaard uit."
-            }
-          },
-          "polling": {
-            "name": "Verversen",
-            "data": {
-              "refresh_interval": "Ververs elke"
-            },
-            "data_description": {
-              "refresh_interval": "Hoe vaak de integratie PostNL controleert op pakketupdates. Een langzamer interval is vriendelijker voor PostNL; de standaard van 30 minuten is ruim voldoende voor de meeste pakketten."
-            }
-          }
+        "title": "Bezorgde pakketten",
+        "data": {
+          "delivered_filter_type": "Filteren op",
+          "delivered_filter_amount": "Aantal"
+        },
+        "data_description": {
+          "delivered_filter_type": "Toon bezorgde pakketten van de afgelopen X dagen, of beperk tot de X meest recente.",
+          "delivered_filter_amount": "Aantal dagen of pakketten om weer te geven."
         }
       }
     }
   },
   "selector": {
-    "refresh_interval": {
-      "options": {
-        "15": "15 minuten",
-        "30": "30 minuten",
-        "60": "60 minuten",
-        "120": "120 minuten",
-        "240": "240 minuten"
-      }
-    },
     "delivered_filter_type": {
       "options": {
         "days": "Dagen",
@@ -95,25 +62,7 @@
       }
     }
   },
-  "device_automation": {
-    "trigger_type": {
-      "parcel_registered": "Een pakket is geregistreerd",
-      "parcel_status_changed": "De status van een pakket is gewijzigd",
-      "parcel_delivery_time_changed": "De verwachte bezorgtijd van een pakket is gewijzigd",
-      "letter_announced": "Een brief is aangekondigd"
-    }
-  },
   "entity": {
-    "button": {
-      "refresh": {
-        "name": "Verversen"
-      }
-    },
-    "calendar": {
-      "deliveries": {
-        "name": "Bezorgingen"
-      }
-    },
     "sensor": {
       "incoming_parcels": {
         "name": "Inkomende pakketten",
@@ -130,6 +79,10 @@
         "name": "Bezorgde pakketten",
         "unit_of_measurement": "pakketten"
       },
+      "outgoing_delivered_parcels": {
+        "name": "Bezorgde uitgaande pakketten",
+        "unit_of_measurement": "pakketten"
+      },
       "next_delivery": {
         "name": "Volgende bezorging"
       },
@@ -142,7 +95,7 @@
         "unit_of_measurement": "brieven"
       },
       "last_update": {
-        "name": "Laatste succesvolle update"
+        "name": "Laatste update"
       }
     },
     "image": {

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -15,6 +15,7 @@ from custom_components.postnl.sensor import (
     PostNLIncomingParcelsSensor,
     PostNLLettersSensor,
     PostNLNextDeliverySensor,
+    PostNLOutgoingDeliveredParcelsSensor,
     PostNLOutgoingParcelsSensor,
     PostNLParcelSensor,
 )
@@ -27,11 +28,13 @@ def _coordinator(
     receiver: list[dict] | None = None,
     sender: list[dict] | None = None,
     delivered_receiver: list[dict] | None = None,
+    delivered_sender: list[dict] | None = None,
     letters: list[dict] | None = None,
 ) -> MagicMock:
     coordinator = MagicMock()
     coordinator.data = {"receiver": receiver or [], "sender": sender or []}
     coordinator.delivered_receiver = delivered_receiver or []
+    coordinator.delivered_sender = delivered_sender or []
     coordinator.letters = letters or []
     coordinator.last_update_success = True
     return coordinator
@@ -217,6 +220,30 @@ def test_delivered_sensor_reads_from_coordinator_delivered_receiver():
     assert parcels[0]["barcode"] == "D1"
     assert parcels[0]["sender"] == "Sender"
     assert parcels[0]["delivered_at"] == "2026-06-15T10:00:00Z"
+
+
+def test_outgoing_delivered_sensor_reads_from_coordinator_delivered_sender():
+    delivered = [_parcel(
+        barcode="OD1",
+        delivered=True,
+        status=ParcelStatus.DELIVERED,
+        raw_status="Pakket is bezorgd",
+        delivered_at="2026-06-15T10:00:00Z",
+    )]
+    sensor = PostNLOutgoingDeliveredParcelsSensor(
+        _coordinator(delivered_sender=delivered), _USERINFO
+    )
+    assert sensor.native_value == 1
+    assert sensor.unique_id == "abc-123_outgoing_delivered_parcels"
+    parcels = sensor.extra_state_attributes["parcels"]
+    assert parcels[0]["barcode"] == "OD1"
+    assert parcels[0]["delivered_at"] == "2026-06-15T10:00:00Z"
+
+
+def test_outgoing_delivered_sensor_empty_when_no_delivered_sender():
+    sensor = PostNLOutgoingDeliveredParcelsSensor(_coordinator(), _USERINFO)
+    assert sensor.native_value == 0
+    assert sensor.extra_state_attributes["parcels"] == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# Add sensor for delivered outgoing parcels

## Motivation

The existing `PostNLOutgoingParcelsSensor` only exposes parcels that are still in transit
(`delivered == False`). Once an outgoing parcel is delivered to the recipient it silently
disappears — there is no way to see recently delivered sent parcels in Home Assistant.

This PR adds a dedicated `PostNLOutgoingDeliveredSensor` that surfaces those parcels,
consistent with how `PostNLDeliveredParcelsSensor` already handles delivered incoming parcels.

## Changes

### `coordinator.py`

Added `self.delivered_sender: list[dict] = []` alongside `self.delivered_receiver` in
`__init__`, and populated it in `_async_update_data` after the receiver block:

```python
delivered_sender = [p for p in data['sender'] if p.get('delivered')]
self.delivered_sender = sort_parcels_by_ts(
    self._apply_delivered_filter(delivered_sender),
    'delivered_at',
    descending=True,
)
```

The same `_apply_delivered_filter` and `sort_parcels_by_ts` helpers are used as for
`delivered_receiver`, so the days/count filter setting applies to both.

### `sensor.py`

- Added `PostNLOutgoingDeliveredSensor`, mirroring `PostNLDeliveredParcelsSensor`:
  - `_attr_translation_key = "outgoing_delivered_parcels"`
  - `unique_id = f"{account_id}_outgoing_delivered_parcels"`
  - `entity_id` is pinned to `sensor.{account_id}_postnl_outgoing_delivered_parcels` so the
    entity ID is always derived from the English key regardless of the HA UI language at
    first-creation time
  - `extra_state_attributes` returns `{"parcels": self._parcels}` from
    `coordinator.delivered_sender`
- Added `f"{account_id}_outgoing_delivered_parcels"` to `non_parcel_unique_ids`
- Registered the sensor in the `entities` list in `async_setup_entry`

### `translations/en.json` and `translations/nl.json`

Added the `outgoing_delivered_parcels` key to the `entity.sensor` section:

| Language | Name |
|----------|------|
| English  | Delivered outgoing parcels |
| Dutch    | Bezorgde uitgaande pakketten |

## Test plan

- [ ] Outgoing parcels still in transit appear in `PostNLOutgoingParcelsSensor` as before
- [ ] Delivered outgoing parcels appear in `PostNLOutgoingDeliveredSensor` with correct
      barcode, status and delivery date
- [ ] The delivered filter (days / count) in the integration options applies to both incoming
      and outgoing delivered parcels
- [ ] No existing sensors are affected
- [ ] Entity ID is `sensor.{account_id}_postnl_outgoing_delivered_parcels` on a fresh install
