### PR TITLE
Refresh the PostNL bearer token before on-demand letter-image fetches

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,15 @@ entities. Runtime-only; do not move it back into a platform.
 - **API clients are reused across polls** — rebuilt only when the access token
   changes (`_api_token`); each owns a `requests.Session` connection pool that would
   otherwise leak every poll.
+- **Anything that calls `jouw_api` outside `_async_update_data` must go through
+  `coordinator.async_get_jouw_api()`, never read `coordinator.jouw_api` directly.**
+  That poll method's own token-refresh-then-maybe-rebuild logic now lives in
+  `async_get_jouw_api()`; `_async_update_data` just awaits it. `PostNLLetterImage.async_image()`
+  is the reason this exists — it runs on demand, whenever a client requests the
+  photo, independently of the poll cycle, so `jouw_api`'s baked-in bearer token can
+  have expired since the last poll (30 min default interval; PostNL's own access
+  tokens are not guaranteed to live that long) — reading the cached client directly
+  produced a 401 on every fetch until the next poll happened to refresh it.
 - `aiohttp.ClientError` is not caught in the coordinator (wrapped automatically);
   `requests` errors *are* caught (executor jobs re-raise them).
 - **`jouw.postnl.nl` is the universal backend — never route to `.be`.** The GraphQL

--- a/custom_components/postnl/coordinator.py
+++ b/custom_components/postnl/coordinator.py
@@ -123,17 +123,31 @@ class PostNLCoordinator(DataUpdateCoordinator):
             self._cached_device_id = device.id
         return self._cached_device_id
 
+    async def async_get_jouw_api(self) -> PostNLJouwAPI:
+        """Return ``jouw_api``, refreshing the bearer token first if it has expired.
+
+        Every poll goes through ``_async_update_data`` below, which always
+        refreshes before use — but ``PostNLLetterImage.async_image()`` calls this
+        on demand, whenever a client actually requests the photo, independently of
+        the poll cycle. ``jouw_api`` bakes its bearer token into the
+        ``requests.Session`` once at construction (see its docstring) and is only
+        rebuilt here when the token has actually changed, same as
+        ``_async_update_data`` — so a poll shortly after an on-demand image fetch
+        does not throw away a connection pool for nothing.
+        """
+        auth: AsyncConfigEntryAuth = self.config_entry.runtime_data.auth
+        await auth.check_and_refresh_token()
+        if self.jouw_api is None or auth.access_token != self._api_token:
+            self._api_token = auth.access_token
+            self.graphq_api = PostNLGraphql(self._api_token)
+            self.jouw_api = PostNLJouwAPI(self._api_token)
+        return self.jouw_api
+
     async def _async_update_data(self) -> dict[str, list[dict]]:
         _LOGGER.debug("Starting data update for PostNL.")
         try:
-            auth: AsyncConfigEntryAuth = self.config_entry.runtime_data.auth
             _LOGGER.debug("Authenticating with PostNL API.")
-            await auth.check_and_refresh_token()
-
-            if self.graphq_api is None or auth.access_token != self._api_token:
-                self._api_token = auth.access_token
-                self.graphq_api = PostNLGraphql(self._api_token)
-                self.jouw_api = PostNLJouwAPI(self._api_token)
+            await self.async_get_jouw_api()
 
             data: dict[str, list[dict]] = {
                 'receiver': [],

--- a/custom_components/postnl/image.py
+++ b/custom_components/postnl/image.py
@@ -180,8 +180,17 @@ class PostNLLetterImage(CoordinatorEntity[PostNLCoordinator], ImageEntity):
             return self._cached_bytes
 
         try:
+            # A client can request this photo at any point between polls, not
+            # just right after one — the bearer token baked into jouw_api can
+            # have expired since the last poll refreshed it (the default poll
+            # interval is 30 minutes; PostNL's own access tokens do not
+            # necessarily live that long). Ensure it is current before the
+            # fetch instead of trusting whatever the coordinator last cached,
+            # or this 401s. See CLAUDE.md — do not read
+            # ``self.coordinator.jouw_api`` directly here.
+            jouw_api = await self.coordinator.async_get_jouw_api()
             image_bytes, content_type = await self.hass.async_add_executor_job(
-                self.coordinator.jouw_api.image, url
+                jouw_api.image, url
             )
         except Exception as err:  # noqa: BLE001 - never let a bad image break the entity
             _LOGGER.warning(

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,6 +1,6 @@
 """Tests for the PostNL coordinator helpers and transform_shipment."""
 from datetime import datetime, timezone
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 from custom_components.postnl.const import (
     CAPABILITIES,
@@ -1510,6 +1510,62 @@ async def test_transform_shipment_falls_back_to_shipment_fields_on_tt_failure(ha
     assert parcel["barcode"] == "3SABC"
     assert parcel["planned_from"] == "2026-06-17T14:00:00Z"
     assert parcel["status"] == ParcelStatus.UNKNOWN
+
+
+# ---------------------------------------------------------------------------
+# async_get_jouw_api — token-refresh-before-use for the on-demand image path
+# ---------------------------------------------------------------------------
+
+
+def _make_auth_coordinator(hass, *, access_token: str = "tok1"):
+    entry = MagicMock()
+    entry.options = {}
+    auth = MagicMock()
+    auth.check_and_refresh_token = AsyncMock()
+    auth.access_token = access_token
+    entry.runtime_data.auth = auth
+    coordinator = PostNLCoordinator(hass, entry)
+    return coordinator, auth
+
+
+async def test_async_get_jouw_api_refreshes_token_before_returning(hass):
+    coordinator, auth = _make_auth_coordinator(hass)
+    await coordinator.async_get_jouw_api()
+    auth.check_and_refresh_token.assert_awaited_once()
+
+
+async def test_async_get_jouw_api_builds_client_on_first_call(hass):
+    coordinator, _ = _make_auth_coordinator(hass)
+    assert coordinator.jouw_api is None
+    result = await coordinator.async_get_jouw_api()
+    assert result is coordinator.jouw_api
+    assert coordinator.jouw_api is not None
+    assert coordinator.graphq_api is not None
+
+
+async def test_async_get_jouw_api_reuses_client_when_token_unchanged(hass):
+    # Regression guard for the "API clients are reused across polls" rule in
+    # CLAUDE.md — a client each carries its own requests.Session connection
+    # pool, so rebuilding on every on-demand image fetch would leak one per
+    # fetch instead of reusing the poll cycle's.
+    coordinator, _ = _make_auth_coordinator(hass)
+    first = await coordinator.async_get_jouw_api()
+    second = await coordinator.async_get_jouw_api()
+    assert first is second
+
+
+async def test_async_get_jouw_api_rebuilds_client_when_token_changed(hass):
+    # The actual bug this guards against: PostNLLetterImage.async_image() used
+    # to read coordinator.jouw_api directly, so a bearer token that expired
+    # between polls (the default poll interval is 30 minutes; PostNL's own
+    # access tokens are not guaranteed to live that long) produced a 401 on
+    # every image fetch until the next poll happened to refresh it.
+    coordinator, auth = _make_auth_coordinator(hass, access_token="tok1")
+    first = await coordinator.async_get_jouw_api()
+    auth.access_token = "tok2"
+    second = await coordinator.async_get_jouw_api()
+    assert first is not second
+    assert coordinator._api_token == "tok2"
 
 
 def test_capabilities_are_known_values():

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -25,6 +25,9 @@ def _coordinator(letters: list[dict] | None = None) -> MagicMock:
     coordinator.async_add_listener = MagicMock(return_value=lambda: None)
     coordinator.last_update_success = True
     coordinator.jouw_api = MagicMock()
+    # async_image() must go through this (token-refresh-before-use), never
+    # read coordinator.jouw_api directly — see test_async_image_refreshes_token_before_fetch.
+    coordinator.async_get_jouw_api = AsyncMock(return_value=coordinator.jouw_api)
     return coordinator
 
 
@@ -201,6 +204,25 @@ async def test_async_image_returns_none_when_executor_raises():
     assert await img.async_image() is None
     # Cache should still be unset so the next attempt will retry.
     assert img._cached_bytes is None
+
+
+@pytest.mark.asyncio
+async def test_async_image_refreshes_token_before_fetch():
+    # Regression test: async_image() used to read coordinator.jouw_api
+    # directly, so a bearer token that expired between polls (default poll
+    # interval 30 min; PostNL's own access tokens are not guaranteed to live
+    # that long) produced a 401 on every fetch until the next poll happened to
+    # refresh it — see CLAUDE.md and PostNLCoordinator.async_get_jouw_api.
+    coordinator = _coordinator([_letter("L1", image_url="https://example.com/img")])
+    img, hass = _make_image(coordinator, letter_id="L1")
+    hass.async_add_executor_job = AsyncMock(return_value=(b"fresh", "image/png"))
+
+    await img.async_image()
+
+    coordinator.async_get_jouw_api.assert_awaited_once()
+    hass.async_add_executor_job.assert_called_once_with(
+        coordinator.jouw_api.image, "https://example.com/img"
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## The problem

Letter photos work right after a letter is announced, then go missing — confirmed live in HA's logs:

```
Could not fetch PostNL letter image mailitem-2625660529_2026-07-28:
401 Client Error: Unauthorized for url: https://jouw.postnl.nl/services/mymail/api/image/...
```

This is PostNL's API correctly rejecting an expired bearer token — not a bug on their end. The bug is on ours.

## Root cause

`PostNLJouwAPI.__init__` bakes the bearer token into its `requests.Session` once, at construction. `_async_update_data` refreshes the token and rebuilds the client *before* every poll, so `letters()` never sees a stale token. But `PostNLLetterImage.async_image()` runs independently of the poll cycle — whenever a client actually requests the photo — and used to read `coordinator.jouw_api` directly, with no refresh check of its own.

The default poll interval is 30 minutes (`DEFAULT_REFRESH_INTERVAL`); PostNL's own access tokens aren't guaranteed to live that long. Any image request landing in that gap 401s, even though the coordinator's *own* data is completely healthy.

## Fix

Moved the refresh-then-maybe-rebuild logic out of `_async_update_data` into a new `PostNLCoordinator.async_get_jouw_api()`, and made `async_image()` call that instead of reading `coordinator.jouw_api` directly. `_async_update_data` now just awaits the same method, so its own behavior (and the "API clients are reused across polls" rule in CLAUDE.md — clients are still rebuilt only when the token actually changed, not on every fetch) is unchanged.

Added coordinator tests for the new method (refreshes token, builds on first call, reuses when unchanged, rebuilds when changed) and a regression test on the image entity asserting `async_image()` goes through `async_get_jouw_api()` rather than reading the cached client directly. CLAUDE.md updated with the new rule.

Found and diagnosed via jonisnet/hki-parcels-card, since that's how I was viewing (or trying to view) the missing photos.