### PR TITLE
Bump version to 4.8.2

### DIFF
--- a/custom_components/postnl/manifest.json
+++ b/custom_components/postnl/manifest.json
@@ -9,5 +9,5 @@
   "issue_tracker": "https://github.com/ha-parcel-integrations/ha-postnl/issues",
   "quality_scale": "silver",
   "requirements": ["gql", "requests"],
-  "version": "4.8.1"
+  "version": "4.8.2"
 }


### PR DESCRIPTION
## Bug fixes
- recognise two more PostNL status codes instead of reporting unknown: "Sorry, bezorgmoment is bijgewerkt" and "Leeg" (#20)

## Credits
- Thanks to @gargs for reporting.

---

📦 [See every supported carrier](https://ha-parcel-integrations.github.io/carriers/) — new ones land regularly.
💛 [Support the project](https://ha-parcel-integrations.github.io/sponsor/)
