### PR TITLE
Bump version to 4.9.0

### DIFF
--- a/custom_components/postnl/manifest.json
+++ b/custom_components/postnl/manifest.json
@@ -9,5 +9,5 @@
   "issue_tracker": "https://github.com/ha-parcel-integrations/ha-postnl/issues",
   "quality_scale": "silver",
   "requirements": ["gql", "requests"],
-  "version": "4.8.2"
+  "version": "4.9.0"
 }


### PR DESCRIPTION
## New features
- remove the "Refresh every" setting and always poll PostNL on the adaptive schedule that used to be the "Automatic" choice, checking more often while a parcel is out for delivery, less often while it's still on its way, and quietly overnight between midnight and 6 AM apart from two catch-up checks, so a new shipment or a letter announced in MyMail still shows up on its own; installs that were still on a fixed interval move over automatically with nothing to change

## Bug fixes
- recognise another PostNL status instead of reporting unknown: "Zending is bezorgd op de afgesproken plek" now correctly shows as delivered

---

📦 [See every supported carrier](https://ha-parcel-integrations.github.io/carriers/) — new ones land regularly.
💛 [Support the project](https://ha-parcel-integrations.github.io/sponsor/)